### PR TITLE
[codex] 마이크 입력 크기 설정 추가

### DIFF
--- a/codex-dictation/README.md
+++ b/codex-dictation/README.md
@@ -126,6 +126,7 @@ codex-dictation\run_codex_terminal.bat
 - 기록 저장: `codex_dictation.history.jsonl`
 - 설정 저장: `codex_dictation.settings.json`
 - 활동 로그: `codex_dictation.log`
+- 입력 감도 보정: 설정의 `Input Gain`으로 마이크 입력 크기를 조절할 수 있습니다. 기본값 `1.0`은 기존 동작과 동일하고, 작은 마이크는 `1.2`~`2.0` 정도로 키워 볼 수 있습니다.
 
 ## 로컬 LLM 교정
 

--- a/codex-dictation/codex_dictation.py
+++ b/codex-dictation/codex_dictation.py
@@ -85,7 +85,7 @@ DELETE_COUNT_WORDS={
 
 @dataclass
 class Settings:
-    input_device:str=""; sample_rate:int=16000; channels:int=1; whisper_model:str="large-v3-turbo"; whisper_device:str="auto"; whisper_compute_type:str="auto"
+    input_device:str=""; sample_rate:int=16000; channels:int=1; input_gain:float=1.0; whisper_model:str="large-v3-turbo"; whisper_device:str="auto"; whisper_compute_type:str="auto"
     language:str="auto"; initial_prompt:str=""; record_hotkey:str="f8"; always_listen_hotkey:str="f7"; paste_last_hotkey:str="f9"
     toggle_output_hotkey:str="f10"; toggle_enter_hotkey:str="f11"; output_mode:str="type"; paste_hotkey:str="ctrl+v"; auto_enter:bool=False
     trim_silence:bool=True; trim_threshold:float=0.008; normalize_whitespace:bool=True; max_record_seconds:int=45; min_record_seconds:float=0.25
@@ -443,6 +443,7 @@ def load_settings()->Settings:
         s=Settings(); save_settings(s); return s
     data=json.loads(SETTINGS_PATH.read_text(encoding="utf-8")); ok={f.name for f in Settings.__dataclass_fields__.values()}
     settings=Settings(**{k:v for k,v in data.items() if k in ok})
+    settings.input_gain=max(float(settings.input_gain),0.0)
     settings.language=normalize_language_value(settings.language)
     settings.llm_profile=normalize_llm_profile_value(settings.llm_profile)
     return settings
@@ -570,6 +571,14 @@ def rms_level(audio:np.ndarray)->float:
     if audio.size==0:
         return 0.0
     return float(np.sqrt(np.mean(np.square(audio))))
+
+def apply_input_gain(audio:np.ndarray,gain:float)->np.ndarray:
+    if audio.size==0:
+        return audio
+    gain=max(float(gain),0.0)
+    if gain==1.0:
+        return audio
+    return np.clip((audio*gain).astype(np.float32,copy=False),-1.0,1.0).astype(np.float32,copy=False)
 
 def normalize_text(text:str)->str: return " ".join(text.replace("\r"," ").replace("\n"," ").split()).strip()
 def initial_prompt_for_commands(settings:Settings)->str:
@@ -800,7 +809,7 @@ class Recorder:
     def should_stop(self)->bool: return self.on and self.s.enable_auto_stop and self.duration()>=self.s.min_record_seconds and time.monotonic()-self.last_voice>=self.s.auto_stop_silence_seconds
     def _cb(self,indata,frames,time_info,status):
         if status: self.log(f"Audio status: {status}")
-        mono=indata[:,0].copy()
+        mono=apply_input_gain(indata[:,0].copy(),self.s.input_gain)
         with self.lock: self.chunks.append(mono)
         rms=rms_level(mono)
         threshold=max(self.s.trim_threshold, self.s.voice_trigger_min_rms, self.noise_floor*self.s.voice_trigger_ratio)
@@ -827,7 +836,7 @@ class AlwaysListen:
         audio=np.concatenate(self.chunks).astype(np.float32); self.chunks=[]; self.n=0; self.last_voice=0.0; self.on_audio(audio,"always_listen")
     def _cb(self,indata,frames,time_info,status):
         if status: self.log(f"Always-listen audio status: {status}")
-        mono=indata[:,0].copy()
+        mono=apply_input_gain(indata[:,0].copy(),self.s.input_gain)
         if not self.target_active(): self.reset(); return
         rms=rms_level(mono)
         threshold=max(self.s.trim_threshold, self.s.voice_trigger_min_rms, self.noise_floor*self.s.voice_trigger_ratio)
@@ -889,7 +898,7 @@ class App:
         self.ai_correction_seq=0
         self.ai_prefetch_lock=threading.Lock()
         self.ai_prefetch=AICorrectionPrefetchState()
-        self.vars={k:tk.StringVar(value=str(getattr(self.s,k))) for k in ["input_device","sample_rate","whisper_model","whisper_device","whisper_compute_type","initial_prompt","record_hotkey","always_listen_hotkey","paste_last_hotkey","toggle_output_hotkey","toggle_enter_hotkey","output_mode","paste_hotkey","max_record_seconds","auto_stop_silence_seconds","always_listen_preroll_seconds","llm_model","llm_base_url","llm_timeout_seconds"]}
+        self.vars={k:tk.StringVar(value=str(getattr(self.s,k))) for k in ["input_device","sample_rate","input_gain","whisper_model","whisper_device","whisper_compute_type","initial_prompt","record_hotkey","always_listen_hotkey","paste_last_hotkey","toggle_output_hotkey","toggle_enter_hotkey","output_mode","paste_hotkey","max_record_seconds","auto_stop_silence_seconds","always_listen_preroll_seconds","llm_model","llm_base_url","llm_timeout_seconds"]}
         self.vars["language"]=tk.StringVar(value=language_label(self.s.language))
         self.vars["llm_profile"]=tk.StringVar(value=llm_profile_label(self.s.llm_profile))
         self.bools={k:tk.BooleanVar(value=getattr(self.s,k)) for k in ["auto_enter","trim_silence","normalize_whitespace","beep_feedback","keep_window_on_top","enable_auto_stop","always_listen_enabled","llm_correction_enabled"]}
@@ -899,8 +908,8 @@ class App:
         self.root.columnconfigure(0,weight=1); self.root.rowconfigure(3,weight=1); head=ttk.Frame(self.root,padding=12); head.grid(row=0,column=0,sticky="ew"); head.columnconfigure(1,weight=1)
         ttk.Label(head,text=APP_NAME,font=("Segoe UI",18,"bold")).grid(row=0,column=0,sticky="w"); ttk.Label(head,textvariable=self.status,font=("Segoe UI",10,"bold")).grid(row=0,column=1,sticky="e"); ttk.Label(head,textvariable=self.target).grid(row=1,column=0,columnspan=2,sticky="w",pady=(6,0)); ttk.Label(head,text="F7 항상 듣기, F8 수동 녹음, F9 마지막 문장, F10 출력 모드, F11 Enter 전환 | 음성 명령: 보내, 지워, 다 지워, 전체 비워, 다시 ..., 복사, 붙여넣기, 잘라, 취소, 되돌려, 자동/한국어/영어, 최대화/최소화/복원, 이스케이프/나가기, 일시정지/재생, 앞으로/뒤로 감기").grid(row=2,column=0,columnspan=2,sticky="w",pady=(6,0))
         top=ttk.Frame(self.root,padding=(12,0,12,0)); top.grid(row=1,column=0,sticky="nsew"); top.columnconfigure((0,1),weight=1); left=ttk.LabelFrame(top,text="Recording",padding=12); right=ttk.LabelFrame(top,text="Output, Target, Hotkeys",padding=12); left.grid(row=0,column=0,sticky="nsew",padx=(0,6)); right.grid(row=0,column=1,sticky="nsew",padx=(6,0))
-        self._combo(left,"Input Device","input_device",self.devices,0); self._entry(left,"Sample Rate","sample_rate",1); self._combo(left,"Whisper Model","whisper_model",["tiny","base","small","medium","large-v3-turbo"],2); self._combo(left,"Whisper Device","whisper_device",["auto","cpu","cuda"],3); self._combo(left,"Compute Type","whisper_compute_type",["auto","int8","int8_float16","float16","float32"],4); self._combo(left,"Language","language",["자동","한국어","영어"],5); self._entry(left,"Initial Prompt","initial_prompt",6); self._entry(left,"Max Record Seconds","max_record_seconds",7); self._entry(left,"Speech End Silence Seconds","auto_stop_silence_seconds",8); self._entry(left,"Always Listen Pre-roll Seconds","always_listen_preroll_seconds",9)
-        self._check(left,"Trim leading and trailing silence","trim_silence",10); self._check(left,"Normalize whitespace","normalize_whitespace",11); self._check(left,"Enable manual mode auto stop","enable_auto_stop",12); self._check(left,"Play feedback beeps","beep_feedback",13); self._check(left,"Keep window on top","keep_window_on_top",14)
+        self._combo(left,"Input Device","input_device",self.devices,0); self._entry(left,"Sample Rate","sample_rate",1); self._entry(left,"Input Gain","input_gain",2); self._combo(left,"Whisper Model","whisper_model",["tiny","base","small","medium","large-v3-turbo"],3); self._combo(left,"Whisper Device","whisper_device",["auto","cpu","cuda"],4); self._combo(left,"Compute Type","whisper_compute_type",["auto","int8","int8_float16","float16","float32"],5); self._combo(left,"Language","language",["자동","한국어","영어"],6); self._entry(left,"Initial Prompt","initial_prompt",7); self._entry(left,"Max Record Seconds","max_record_seconds",8); self._entry(left,"Speech End Silence Seconds","auto_stop_silence_seconds",9); self._entry(left,"Always Listen Pre-roll Seconds","always_listen_preroll_seconds",10)
+        self._check(left,"Trim leading and trailing silence","trim_silence",11); self._check(left,"Normalize whitespace","normalize_whitespace",12); self._check(left,"Enable manual mode auto stop","enable_auto_stop",13); self._check(left,"Play feedback beeps","beep_feedback",14); self._check(left,"Keep window on top","keep_window_on_top",15)
         self._combo(right,"Output Mode","output_mode",["paste","clipboard","type"],0); self._entry(right,"Paste Hotkey","paste_hotkey",1); self._check(right,"Press Enter after output","auto_enter",2); self._check(right,"Always listen when target input window is focused","always_listen_enabled",3); self._entry(right,"Always Listen Hotkey","always_listen_hotkey",4); self._entry(right,"Record Hotkey","record_hotkey",5); self._entry(right,"Paste Last Hotkey","paste_last_hotkey",6); self._entry(right,"Toggle Output Hotkey","toggle_output_hotkey",7); self._entry(right,"Toggle Enter Hotkey","toggle_enter_hotkey",8); self._check(right,"Enable local LLM correction command","llm_correction_enabled",9); self._combo(right,"LLM Profile","llm_profile",["균형","정확도","직접지정"],10); self._entry(right,"LLM Model","llm_model",11); self._entry(right,"LLM Base URL","llm_base_url",12); self._entry(right,"LLM Timeout Seconds","llm_timeout_seconds",13)
         btn=ttk.Frame(right); btn.grid(row=13,column=0,columnspan=2,sticky="ew",pady=(14,0)); [btn.columnconfigure(i,weight=1) for i in range(3)]
         for r,c,text,cmd in [(0,0,"Start / Stop Manual",self.toggle_recording),(0,1,"Toggle Always Listen",self.toggle_always_listen),(0,2,"Paste Last",self.paste_last),(1,0,"Save Settings",self.save_from_ui),(1,1,"Doctor",self.show_doctor),(1,2,"Refresh Hotkeys",self.register_hotkeys),(2,0,"Copy Last",self.copy_last)]:
@@ -1072,6 +1081,8 @@ class App:
             elif isinstance(cur,int): setattr(self.s,k,int(raw or "0"))
             elif isinstance(cur,float): setattr(self.s,k,float(raw or "0"))
             else: setattr(self.s,k,raw)
+        self.s.input_gain=max(float(self.s.input_gain),0.0)
+        self.vars["input_gain"].set(str(self.s.input_gain))
         for k,v in self.bools.items(): setattr(self.s,k,bool(v.get()))
         save_settings(self.s); self.rec.s=self.s; self.listen.s=self.s; self.root.attributes("-topmost",self.s.keep_window_on_top); self.refresh_target(); self.refresh_status(); self.log("Settings saved")
     def register_hotkeys(self):

--- a/codex-dictation/codex_dictation.settings.json
+++ b/codex-dictation/codex_dictation.settings.json
@@ -2,6 +2,7 @@
   "input_device": "\ub9c8\uc774\ud06c(3- USB Audio Device)",
   "sample_rate": 16000,
   "channels": 1,
+  "input_gain": 1.0,
   "whisper_model": "large-v3-turbo",
   "whisper_device": "auto",
   "whisper_compute_type": "auto",


### PR DESCRIPTION
## 관련 이슈
- #19

## 배경
현재 받아쓰기 기능은 마이크 입력을 바로 받아서 수동 녹음과 항상 듣기 감지에 사용하고 있습니다. 하지만 환경에 따라 마이크 입력이 작게 들어오는 경우가 있어, 사용자가 OS 설정을 바꾸지 않고도 입력 크기를 직접 보정할 수 있는 옵션이 필요했습니다.

## 사용자 영향
이번 변경 전에는 입력이 작은 마이크를 쓰는 경우 감지 임계값보다 음성이 약하게 들어와 녹음 시작이나 항상 듣기 감지가 둔하게 느껴질 수 있었습니다. 이번 변경 후에는 설정 창의 `Input Gain` 값을 올려 입력 신호를 키울 수 있고, 기본값 `1.0`에서는 기존 동작이 그대로 유지됩니다.

## 원인
오디오 입력 파이프라인에서 마이크 raw input에 대한 사용자 조절용 gain 단계가 없었습니다. 그래서 감도 관련 설정(`trim_threshold`, `voice_trigger_min_rms`, `voice_trigger_ratio`)은 있었지만, 입력 신호 자체를 환경별로 보정하는 방법은 제공되지 않았습니다.

## 수정 내용
`Settings`에 `input_gain` 기본값 `1.0`을 추가했고, 설정 로드 시 음수 값이 들어오지 않도록 보정했습니다. 설정 UI의 Recording 섹션에 `Input Gain` 입력 필드를 추가해 사용자가 직접 값을 조절할 수 있게 했습니다. 실제 오디오 처리에서는 수동 녹음과 항상 듣기 콜백 모두에 같은 gain을 적용하고, 과도한 증폭으로 인한 왜곡을 줄이기 위해 `[-1.0, 1.0]` 범위로 클리핑하도록 했습니다. 기본 설정 파일과 README에도 새 옵션 설명을 반영했습니다.

## 검증
로컬에서 `.venv\Scripts\python.exe -m py_compile codex-dictation\codex_dictation.py`로 문법 검사를 통과했습니다. 이어서 `.venv\Scripts\python.exe codex-dictation\codex_dictation.py --doctor`를 실행해 설정 로드와 기본 런타임 점검이 정상 동작하는 것도 확인했습니다.
