### PR TITLE
[codex] 받아쓰기 도구 단일 실행 파일 패키징 지원

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 AGENTS.md
 __pycache__/
 *.pyc
+codex-dictation/build/
+codex-dictation/dist/
 codex-dictation/codex_dictation.history.jsonl
 codex-dictation/codex_dictation.log
 tmp_*.txt

--- a/codex-dictation/README.md
+++ b/codex-dictation/README.md
@@ -41,6 +41,25 @@ python -m venv .venv
 
 이미 이 저장소의 `.venv`를 쓰고 있다면 마지막 줄만 실행하면 됩니다.
 
+## 단일 실행 파일 빌드
+
+Python 설치와 가상환경 준비가 번거로운 PC로 옮길 때는 `PyInstaller`로 단일 `exe`를 만들 수 있습니다.
+
+```powershell
+codex-dictation\build_codex_dictation_exe.ps1
+```
+
+빌드가 끝나면 아래 파일이 생성됩니다.
+
+```text
+codex-dictation\dist\CodexDictation.exe
+```
+
+메모:
+- `exe`로 실행해도 `codex_dictation.settings.json`, `codex_dictation.history.jsonl`, `codex_dictation.log`는 `exe`가 있는 폴더 옆에 저장됩니다.
+- 첫 실행 시 `faster-whisper` 모델이 PC에 없다면 모델 다운로드는 여전히 한 번 필요합니다.
+- 전역 핫키는 기존처럼 `tools\AutoHotkey` 또는 `run_codex_hotkeys.bat` 흐름을 같이 쓰는 것이 가장 편합니다.
+
 ## 실행
 
 ```powershell
@@ -52,6 +71,8 @@ python -m venv .venv
 ```powershell
 codex-dictation\run_codex_dictation.bat
 ```
+
+`CodexDictation.exe`가 `codex-dictation\dist\` 아래에 있으면 같은 런처가 자동으로 `exe`를 우선 실행합니다.
 
 Codex 터미널만 빠르게 열기:
 

--- a/codex-dictation/build_codex_dictation_exe.ps1
+++ b/codex-dictation/build_codex_dictation_exe.ps1
@@ -1,0 +1,86 @@
+$ErrorActionPreference = "Stop"
+
+function Find-PythonInAncestorVenv {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StartDirectory
+    )
+
+    $current = (Resolve-Path $StartDirectory).Path
+    while ($true) {
+        $candidate = Join-Path $current ".venv\Scripts\python.exe"
+        if (Test-Path $candidate) {
+            return $candidate
+        }
+
+        $parent = Split-Path $current -Parent
+        if (-not $parent -or $parent -eq $current) {
+            break
+        }
+        $current = $parent
+    }
+
+    return $null
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$python = Find-PythonInAncestorVenv -StartDirectory $scriptDir
+
+if (-not $python) {
+    throw ".venv\Scripts\python.exe 를 찾지 못했습니다. 저장소 루트에서 가상환경을 먼저 준비해주세요."
+}
+
+$buildRequirements = Join-Path $scriptDir "requirements-dictation-build.txt"
+$entryScript = Join-Path $scriptDir "codex_dictation.py"
+$distDir = Join-Path $scriptDir "dist"
+$workDir = Join-Path $scriptDir "build"
+
+& $python -m pip install -r $buildRequirements
+if ($LASTEXITCODE -ne 0) {
+    throw "빌드 의존성 설치에 실패했습니다."
+}
+
+& $python -m PyInstaller `
+    --noconfirm `
+    --clean `
+    --onefile `
+    --windowed `
+    --name CodexDictation `
+    --distpath $distDir `
+    --workpath $workDir `
+    --specpath $workDir `
+    --collect-data faster_whisper `
+    --hidden-import sounddevice `
+    --hidden-import soundfile `
+    --hidden-import keyboard `
+    --hidden-import tkinter `
+    --hidden-import tkinter.ttk `
+    --hidden-import tkinter.messagebox `
+    --exclude-module torch `
+    --exclude-module torchaudio `
+    --exclude-module torchvision `
+    --exclude-module lightning `
+    --exclude-module pytorch_lightning `
+    --exclude-module tensorflow `
+    --exclude-module jax `
+    --exclude-module scipy `
+    --exclude-module sklearn `
+    --exclude-module matplotlib `
+    --exclude-module numba `
+    --exclude-module llvmlite `
+    --exclude-module librosa `
+    --exclude-module transformers `
+    --exclude-module so_vits_svc_fork `
+    $entryScript
+
+if ($LASTEXITCODE -ne 0) {
+    throw "PyInstaller 빌드에 실패했습니다."
+}
+
+$exePath = Join-Path $distDir "CodexDictation.exe"
+if (-not (Test-Path $exePath)) {
+    throw "빌드는 끝났지만 실행 파일이 생성되지 않았습니다: $exePath"
+}
+
+Write-Host ""
+Write-Host "빌드 완료: $exePath"

--- a/codex-dictation/codex_dictation.py
+++ b/codex-dictation/codex_dictation.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import numpy as np, sounddevice as sd, soundfile as sf, tkinter as tk
 from tkinter import messagebox, ttk
 
-APP_NAME="Codex Dictation"; ROOT=Path(__file__).resolve().parent; APP_PID=os.getpid()
+def _runtime_root()->Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parent
+
+APP_NAME="Codex Dictation"; ROOT=_runtime_root(); APP_PID=os.getpid()
 SETTINGS_PATH=ROOT/"codex_dictation.settings.json"; HISTORY_PATH=ROOT/"codex_dictation.history.jsonl"; LOG_PATH=ROOT/"codex_dictation.log"
 AI_PREFETCH_CACHE_SIZE=3
 TERMINALS={"windowsterminal.exe","wezterm-gui.exe","conhost.exe","powershell.exe","pwsh.exe","cmd.exe","mintty.exe","alacritty.exe","rio.exe","code.exe","cursor.exe"}

--- a/codex-dictation/launch_codex_dictation.ahk
+++ b/codex-dictation/launch_codex_dictation.ahk
@@ -9,6 +9,7 @@ projectDir := A_ScriptDir
 dictationTitle := "Codex Dictation"
 dictationLauncher := projectDir "\run_codex_dictation.bat"
 dictationScript := projectDir "\codex_dictation.py"
+dictationExe := projectDir "\dist\CodexDictation.exe"
 
 StartDictation(showWindow := false)
 {
@@ -40,14 +41,21 @@ CanRestoreWindow(hwnd)
 
 IsDictationProcessRunning()
 {
-    global dictationScript
+    global dictationScript, dictationExe
     escapedScript := StrReplace(dictationScript, "\", "\\")
-    query := "Select ProcessId from Win32_Process where Name='pythonw.exe' or Name='python.exe'"
+    escapedExe := StrReplace(dictationExe, "\", "\\")
+    query := "Select ProcessId from Win32_Process where Name='pythonw.exe' or Name='python.exe' or Name='CodexDictation.exe'"
     for proc in ComObjGet("winmgmts:").ExecQuery(query)
     {
         cmd := ""
         try cmd := proc.CommandLine
+        exePath := ""
+        try exePath := proc.ExecutablePath
         if InStr(StrLower(cmd), StrLower(escapedScript)) || InStr(StrLower(cmd), StrLower(dictationScript))
+            return true
+        if InStr(StrLower(cmd), StrLower(escapedExe)) || InStr(StrLower(cmd), StrLower(dictationExe))
+            return true
+        if InStr(StrLower(exePath), StrLower(escapedExe)) || InStr(StrLower(exePath), StrLower(dictationExe))
             return true
     }
     return false

--- a/codex-dictation/requirements-dictation-build.txt
+++ b/codex-dictation/requirements-dictation-build.txt
@@ -1,0 +1,2 @@
+-r requirements-dictation.txt
+PyInstaller>=6.19.0

--- a/codex-dictation/run_codex_dictation.bat
+++ b/codex-dictation/run_codex_dictation.bat
@@ -1,9 +1,15 @@
 @echo off
 setlocal
 set "APP_DIR=%~dp0"
+set "DIST_EXE=%APP_DIR%dist\CodexDictation.exe"
 set "REPO_ROOT=%APP_DIR%..\"
 set "PYTHONW=%REPO_ROOT%.venv\Scripts\pythonw.exe"
 set "PYTHON=%REPO_ROOT%.venv\Scripts\python.exe"
+
+if exist "%DIST_EXE%" (
+  start "" "%DIST_EXE%" %*
+  exit /b 0
+)
 
 if exist "%PYTHONW%" (
   start "" "%PYTHONW%" "%APP_DIR%codex_dictation.py" %*


### PR DESCRIPTION
## 요약
`codex-dictation`를 Python 가상환경 없이도 배포할 수 있도록 `PyInstaller` 기반 단일 실행 파일 빌드 흐름을 추가했습니다.

## 문제
현재 받아쓰기 도구는 Python 설치, `.venv` 생성, 패키지 설치를 전제로 실행됩니다. 그래서 새 PC나 다른 사용자 환경에서 바로 실행해보기가 어렵고, 설치 시간이 길어 배포와 테스트가 번거롭습니다.

## 원인
실행 경로가 소스 파일 기준으로 고정되어 있었고, 배포용 빌드 스크립트와 `exe` 우선 실행 흐름이 준비되어 있지 않았습니다. 이 때문에 `frozen` 환경에서는 설정/로그 저장 위치와 런처 동작을 함께 정리해야 했습니다.

## 해결
- `codex-dictation\build_codex_dictation_exe.ps1`와 `requirements-dictation-build.txt`를 추가해 단일 `exe` 빌드 흐름을 만들었습니다.
- `codex_dictation.py`에서 `sys.frozen` 환경을 감지해 설정/로그/히스토리를 실행 파일 기준 경로에 저장하도록 바꿨습니다.
- `run_codex_dictation.bat`가 `dist\CodexDictation.exe`를 우선 실행하도록 조정했습니다.
- `launch_codex_dictation.ahk`가 `CodexDictation.exe` 프로세스도 정상 인식하도록 확장했습니다.
- README와 `.gitignore`를 업데이트해 빌드/실행 방법과 산출물 정리를 문서화했습니다.

## 검증
- `C:\Users\ParkJaeHong\Desktop\실험\exp\.venv\Scripts\python.exe -m py_compile codex-dictation\codex_dictation.py`
- `powershell -ExecutionPolicy Bypass -File codex-dictation\build_codex_dictation_exe.ps1`
- 빌드 결과 `codex-dictation\dist\CodexDictation.exe` 생성 확인
- 최종 산출물 크기 약 `111MB` 확인
- `CodexDictation.exe` 실행 후 `codex-dictation\dist\codex_dictation.settings.json`, `codex-dictation\dist\codex_dictation.log` 생성 확인

Closes #23
