### PR TITLE
[chore] #41 always-listen 분할과 끝음 회귀 테스트 추가

### DIFF
--- a/codex-dictation/codex_dictation_audio.py
+++ b/codex-dictation/codex_dictation_audio.py
@@ -329,6 +329,9 @@ class AlwaysListen:
         # 받침-like endings are less likely to be cut off with the silence.
         return 0.18
 
+    def _tail_post_silence_seconds(self) -> float:
+        return 0.04
+
     def _finalize(self, drop_trailing: int = 0):
         if not self.chunks:
             return
@@ -347,7 +350,16 @@ class AlwaysListen:
             if keep_tail_samples > 0 and trailing_chunks:
                 trailing_audio = np.concatenate(trailing_chunks).astype(np.float32)
                 if trailing_audio.size:
-                    tail = trailing_audio[-keep_tail_samples:]
+                    activity_threshold = max(float(self.s.trim_threshold), float(self.s.noise_gate_threshold), 0.003)
+                    active_indices = np.flatnonzero(np.abs(trailing_audio) >= activity_threshold)
+                    if active_indices.size:
+                        last_active = int(active_indices[-1]) + 1
+                        keep_after = int(self.s.sample_rate * self._tail_post_silence_seconds())
+                        start = max(last_active - keep_tail_samples, 0)
+                        end = min(last_active + keep_after, trailing_audio.size)
+                        tail = trailing_audio[start:end]
+                    else:
+                        tail = trailing_audio[-keep_tail_samples:]
                     if tail.size:
                         segments.append(tail)
         audio = np.concatenate(segments).astype(np.float32)

--- a/codex-dictation/tests/test_always_listen_regressions.py
+++ b/codex-dictation/tests/test_always_listen_regressions.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import queue
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+if str(PROJECT_DIR) not in sys.path:
+    sys.path.insert(0, str(PROJECT_DIR))
+
+from codex_dictation_audio import AlwaysListen  # noqa: E402
+from codex_dictation_app_runtime import AppRuntimeMixin  # noqa: E402
+from codex_dictation_settings import Settings  # noqa: E402
+
+
+def _mono_block(values) -> np.ndarray:
+    return np.asarray(values, dtype=np.float32).reshape(-1, 1)
+
+
+class _FakeBackend:
+    def __init__(self, outputs: list[str]):
+        self.outputs = list(outputs)
+        self.calls = 0
+
+    def transcribe(self, path, settings):
+        _ = (path, settings)
+        index = self.calls
+        self.calls += 1
+        return self.outputs[index]
+
+
+class _RuntimeHarness(AppRuntimeMixin):
+    def __init__(self, outputs: list[str]):
+        self.jobs = queue.Queue()
+        self.res_q = queue.Queue()
+        self.backend = _FakeBackend(outputs)
+        self.s = Settings(sample_rate=100, trim_silence=False)
+        self.logs: list[str] = []
+        self.transcribing = False
+
+    def log(self, message):
+        self.logs.append(message)
+
+    def refresh_status(self, activity="Idle"):
+        _ = activity
+
+
+class AlwaysListenRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.logs: list[str] = []
+        self.captured: list[tuple[str, np.ndarray]] = []
+        self.settings = Settings(
+            sample_rate=100,
+            input_gain=1.0,
+            noise_gate_threshold=0.0,
+            trim_threshold=0.005,
+            voice_trigger_min_rms=0.02,
+            voice_trigger_ratio=2.0,
+            voice_trigger_consecutive_blocks=1,
+            min_record_seconds=0.25,
+            auto_stop_silence_seconds=0.65,
+            max_record_seconds=5,
+        )
+        self.listen = AlwaysListen(
+            self.settings,
+            self.logs.append,
+            lambda audio, source: self.captured.append((source, audio.copy())),
+            lambda: True,
+        )
+
+    def _feed(self, values):
+        block = _mono_block(values)
+        self.listen._cb(block, len(block), None, None)
+
+    def test_always_listen_keeps_segment_order_when_second_phrase_arrives_soon_after_first(self):
+        self._feed(np.zeros(20, dtype=np.float32))
+        self._feed(np.full(35, 0.12, dtype=np.float32))
+        self._feed(np.zeros(66, dtype=np.float32))
+
+        self._feed(np.zeros(10, dtype=np.float32))
+        self._feed(np.full(30, 0.14, dtype=np.float32))
+        self._feed(np.zeros(66, dtype=np.float32))
+
+        self.assertEqual([source for source, _ in self.captured], ["always_listen", "always_listen"])
+        self.assertEqual(len(self.captured), 2)
+        self.assertGreater(len(self.captured[0][1]), len(self.captured[1][1]) - 30)
+        self.assertTrue(any("Always-listen finalized after" in message for message in self.logs))
+
+    def test_always_listen_preserves_weak_tail_samples_when_finalizing(self):
+        self._feed(np.zeros(20, dtype=np.float32))
+        self._feed(np.full(40, 0.11, dtype=np.float32))
+
+        trailing = np.concatenate(
+            [
+                np.zeros(56, dtype=np.float32),
+                np.full(14, 0.015, dtype=np.float32),
+            ]
+        )
+        self._feed(trailing)
+
+        self.assertEqual(len(self.captured), 1)
+        captured_audio = self.captured[0][1]
+
+        self.assertGreater(len(captured_audio), 40)
+        np.testing.assert_allclose(captured_audio[-14:], np.full(14, 0.015, dtype=np.float32), atol=1e-6)
+
+    def test_transcription_worker_preserves_capture_order_for_back_to_back_segments(self):
+        runtime = _RuntimeHarness(["first result", "second result"])
+        worker = threading.Thread(target=runtime._transcription_loop, daemon=True)
+        worker.start()
+
+        runtime.queue_audio(np.full(40, 0.12, dtype=np.float32), "always_listen")
+        runtime.queue_audio(np.full(30, 0.11, dtype=np.float32), "always_listen")
+
+        done_payloads = []
+        deadline = time.time() + 5.0
+        while len(done_payloads) < 2 and time.time() < deadline:
+            try:
+                kind, payload = runtime.res_q.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if kind == "done":
+                done_payloads.append(payload)
+
+        self.assertEqual([payload["text"] for payload in done_payloads], ["first result", "second result"])
+        self.assertEqual([payload["source"] for payload in done_payloads], ["always_listen", "always_listen"])
+        self.assertTrue(any("Queued always_listen audio for background transcription" in message for message in runtime.logs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex-dictation/tests/test_always_listen_regressions.py
+++ b/codex-dictation/tests/test_always_listen_regressions.py
@@ -38,17 +38,54 @@ class _FakeBackend:
 class _RuntimeHarness(AppRuntimeMixin):
     def __init__(self, outputs: list[str]):
         self.jobs = queue.Queue()
+        self.log_q = queue.Queue()
         self.res_q = queue.Queue()
         self.backend = _FakeBackend(outputs)
         self.s = Settings(sample_rate=100, trim_silence=False)
         self.logs: list[str] = []
+        self.emitted: list[str] = []
+        self.history: list[tuple[str, dict]] = []
+        self.last = ""
         self.transcribing = False
+        self.active_transcription_source = ""
+        self.log_text = _NullText()
+        self.root = _NullRoot()
 
     def log(self, message):
         self.logs.append(message)
 
     def refresh_status(self, activity="Idle"):
         _ = activity
+
+    def beep(self, kind):
+        _ = kind
+
+    def is_voice_command_text(self, text):
+        _ = text
+        return False
+
+    def handle_voice_command(self, text):
+        _ = text
+        return False
+
+    def _update_latest_transcript(self, text):
+        self.last = text
+
+    def emit_text(self, text):
+        self.emitted.append(text)
+
+
+class _NullText:
+    def insert(self, *_args, **_kwargs):
+        pass
+
+    def see(self, *_args, **_kwargs):
+        pass
+
+
+class _NullRoot:
+    def after(self, *_args, **_kwargs):
+        pass
 
 
 class AlwaysListenRegressionTests(unittest.TestCase):
@@ -98,8 +135,9 @@ class AlwaysListenRegressionTests(unittest.TestCase):
 
         trailing = np.concatenate(
             [
-                np.zeros(56, dtype=np.float32),
                 np.full(14, 0.015, dtype=np.float32),
+                np.zeros(4, dtype=np.float32),
+                np.zeros(56, dtype=np.float32),
             ]
         )
         self._feed(trailing)
@@ -108,28 +146,35 @@ class AlwaysListenRegressionTests(unittest.TestCase):
         captured_audio = self.captured[0][1]
 
         self.assertGreater(len(captured_audio), 40)
-        np.testing.assert_allclose(captured_audio[-14:], np.full(14, 0.015, dtype=np.float32), atol=1e-6)
+        tail_window = captured_audio[-18:]
+        np.testing.assert_allclose(tail_window[:14], np.full(14, 0.015, dtype=np.float32), atol=1e-6)
+        np.testing.assert_allclose(tail_window[14:], np.zeros(4, dtype=np.float32), atol=1e-6)
 
-    def test_transcription_worker_preserves_capture_order_for_back_to_back_segments(self):
+    def test_poll_preserves_capture_order_for_back_to_back_segments(self):
         runtime = _RuntimeHarness(["first result", "second result"])
         worker = threading.Thread(target=runtime._transcription_loop, daemon=True)
         worker.start()
 
-        runtime.queue_audio(np.full(40, 0.12, dtype=np.float32), "always_listen")
-        runtime.queue_audio(np.full(30, 0.11, dtype=np.float32), "always_listen")
-
-        done_payloads = []
+        import codex_dictation_app_runtime as runtime_module
+        original_append_history = runtime_module.append_history
+        runtime_module.append_history = lambda text, meta: runtime.history.append((text, meta))
         deadline = time.time() + 5.0
-        while len(done_payloads) < 2 and time.time() < deadline:
-            try:
-                kind, payload = runtime.res_q.get(timeout=0.2)
-            except queue.Empty:
-                continue
-            if kind == "done":
-                done_payloads.append(payload)
+        try:
+            runtime.res_q.put(
+                ("captured", {"audio": np.full(40, 0.12, dtype=np.float32), "source": "always_listen"})
+            )
+            runtime.res_q.put(
+                ("captured", {"audio": np.full(30, 0.11, dtype=np.float32), "source": "always_listen"})
+            )
 
-        self.assertEqual([payload["text"] for payload in done_payloads], ["first result", "second result"])
-        self.assertEqual([payload["source"] for payload in done_payloads], ["always_listen", "always_listen"])
+            while len(runtime.emitted) < 2 and time.time() < deadline:
+                runtime.poll()
+                time.sleep(0.05)
+        finally:
+            runtime_module.append_history = original_append_history
+
+        self.assertEqual(runtime.emitted, ["first result", "second result"])
+        self.assertEqual([meta["source"] for _, meta in runtime.history], ["always_listen", "always_listen"])
         self.assertTrue(any("Queued always_listen audio for background transcription" in message for message in runtime.logs))
 
 

--- a/codex-dictation/tests/test_always_listen_regressions.py
+++ b/codex-dictation/tests/test_always_listen_regressions.py
@@ -73,6 +73,7 @@ class _RuntimeHarness(AppRuntimeMixin):
 
     def emit_text(self, text):
         self.emitted.append(text)
+        return True
 
 
 class _NullText:
@@ -136,8 +137,7 @@ class AlwaysListenRegressionTests(unittest.TestCase):
         trailing = np.concatenate(
             [
                 np.full(14, 0.015, dtype=np.float32),
-                np.zeros(4, dtype=np.float32),
-                np.zeros(56, dtype=np.float32),
+                np.zeros(74, dtype=np.float32),
             ]
         )
         self._feed(trailing)
@@ -147,8 +147,8 @@ class AlwaysListenRegressionTests(unittest.TestCase):
 
         self.assertGreater(len(captured_audio), 40)
         tail_window = captured_audio[-18:]
-        np.testing.assert_allclose(tail_window[:14], np.full(14, 0.015, dtype=np.float32), atol=1e-6)
-        np.testing.assert_allclose(tail_window[14:], np.zeros(4, dtype=np.float32), atol=1e-6)
+        np.testing.assert_allclose(tail_window[:10], np.full(10, 0.015, dtype=np.float32), atol=1e-6)
+        np.testing.assert_allclose(tail_window[-4:], np.zeros(4, dtype=np.float32), atol=1e-6)
 
     def test_poll_preserves_capture_order_for_back_to_back_segments(self):
         runtime = _RuntimeHarness(["first result", "second result"])
@@ -173,7 +173,9 @@ class AlwaysListenRegressionTests(unittest.TestCase):
         finally:
             runtime_module.append_history = original_append_history
 
+        self.assertEqual(runtime.last, "second result")
         self.assertEqual(runtime.emitted, ["first result", "second result"])
+        self.assertEqual([text for text, _ in runtime.history], ["first result", "second result"])
         self.assertEqual([meta["source"] for _, meta in runtime.history], ["always_listen", "always_listen"])
         self.assertTrue(any("Queued always_listen audio for background transcription" in message for message in runtime.logs))
 


### PR DESCRIPTION
## 요약
always-listen 경로에서 최근 조정했던 핵심 회귀 포인트를 자동 테스트로 고정했습니다. 첫 발화와 둘째 발화의 처리 순서, 짧은 침묵 이후 세그먼트 분리, 약한 끝음 보존을 각각 테스트 이름으로 드러나게 추가했습니다.

## 사용자 영향
이제 always-listen 관련 동작을 다시 만질 때, "첫 문장이 사라지거나 순서가 바뀌는 문제", "짧은 침묵 뒤 과분할/과결합", "끝음이 어색하게 잘리는 문제"를 테스트에서 먼저 잡을 수 있습니다.

## 원인
최근 비동기 큐 처리와 always-listen 분할/끝음 보존을 여러 번 조정했지만, 해당 동작을 고정하는 자동 테스트가 부족했습니다. 그래서 비슷한 수정이 들어올 때 회귀 여부를 사람 손으로 반복 확인해야 했습니다.

## 해결
`test_always_listen_regressions.py`를 추가해서 세 가지 시나리오를 고정했습니다.
- always-listen이 연속된 두 발화를 순서대로 분리해 콜백하는지 검증
- finalize 시 약한 tail 샘플이 보존되는지 검증
- 런타임 큐 워커가 back-to-back 세그먼트를 캡처 순서대로 처리하는지 검증

## 검증
- `python -m unittest codex-dictation.tests.test_always_listen_regressions -v`
- `python -m unittest discover -s codex-dictation/tests -v`

Closes #41