### PR TITLE
[chore] #42 공유용 로그와 결과 마스킹 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Codex CLI에 붙여 쓰는 Windows용 로컬 받아쓰기 프로젝트입니다.
   - RTX 4060 기준 실험 결과 정리 문서
 - `results_sovits_realtime.json`
   - 벤치마크 결과 원본 데이터
+- `results_sovits_realtime.share.json`
+  - 공유용으로 경로/로컬 호스트 정보를 마스킹한 결과 복사본
 
 요약:
 - 워밍업 이후 기준으로는 `거의 실시간`에 가까운 결과가 나왔고

--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Codex CLI에 붙여 쓰는 Windows용 로컬 받아쓰기 프로젝트입니다.
 - `sovits_realtime_report.md`
   - RTX 4060 기준 실험 결과 정리 문서
 - `results_sovits_realtime.json`
-  - 벤치마크 결과 원본 데이터
+  - 체크인된 벤치마크 결과 원본 샘플
 - `results_sovits_realtime.share.json`
-  - 공유용으로 경로/로컬 호스트 정보를 마스킹한 결과 복사본
+  - 체크인된 공유용 마스킹 결과 샘플
 
 요약:
 - 워밍업 이후 기준으로는 `거의 실시간`에 가까운 결과가 나왔고
 - 짧은 블록에서는 간헐적인 지연 스파이크가 생길 수 있음을 확인했습니다.
+- 현재 벤치마크 스크립트 실행 결과는 추적 파일을 덮어쓰지 않고 `outputs/sovits-realtime/` 아래에 생성됩니다.
 - 상세 문서: [`experiments/README.md`](./experiments/README.md)
 
 ### `external/`

--- a/codex-dictation/README.md
+++ b/codex-dictation/README.md
@@ -148,6 +148,7 @@ codex-dictation\run_codex_terminal.bat
 - 기록 저장: `%LOCALAPPDATA%\CodexDictation\codex_dictation.history.jsonl`
 - 설정 저장: `%LOCALAPPDATA%\CodexDictation\codex_dictation.settings.json`
 - 활동 로그: `%LOCALAPPDATA%\CodexDictation\codex_dictation.log`
+- 공유용 마스킹: `python codex-dictation/codex_share_safe.py --input %LOCALAPPDATA%\CodexDictation\codex_dictation.log --output outputs\codex_dictation.log.share-safe`
 - 입력 감도 보정: 설정의 `Input Gain`으로 마이크 입력 크기를 조절할 수 있습니다. 기본값 `1.0`은 기존 동작과 동일하고, 작은 마이크는 `1.2`~`2.0` 정도로 키워 볼 수 있습니다.
 - 소음 환경 튜닝: `Noise Gate Threshold`로 작은 배경 소음을 잘라내고, `Audio Preset`으로 조용한 방/보통/시끄러운 방 기준값을 빠르게 적용할 수 있습니다.
 - 상태 가시화: 상단에 현재 `rms`, `threshold`, `voice` 감지 상태와 마지막 LLM 교정 상태를 표시합니다.

--- a/codex-dictation/codex_dictation_utils.py
+++ b/codex-dictation/codex_dictation_utils.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from pathlib import Path
 
-from codex_dictation_settings import HISTORY_PATH, LOG_PATH, ensure_runtime_paths
+from codex_dictation_settings import HISTORY_PATH, LOG_PATH, SETTINGS_PATH, ensure_runtime_paths
+from codex_share_safe import export_share_safe_file
 
 
 def append_app_log(msg: str) -> None:
@@ -36,3 +38,15 @@ def short_log_text(text: str, limit: int = 80) -> str:
     if len(compact) <= limit:
         return compact
     return compact[: limit - 3] + "..."
+
+
+def export_share_safe_runtime_artifacts(output_dir: Path, *, mask_text_fields: bool = False) -> list[Path]:
+    ensure_runtime_paths()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    exported: list[Path] = []
+    for source in (LOG_PATH, HISTORY_PATH, SETTINGS_PATH):
+        if not source.exists():
+            continue
+        destination = output_dir / f"{source.stem}.share-safe{source.suffix}"
+        exported.append(export_share_safe_file(source, destination, mask_text_fields=mask_text_fields))
+    return exported

--- a/codex-dictation/codex_share_safe.py
+++ b/codex-dictation/codex_share_safe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,10 @@ WINDOWS_PATH_PATTERN = re.compile(r"(?P<path>(?<![A-Za-z])(?:[A-Za-z]:[\\/]|\\\\
 LOCAL_HOST_URL_PATTERN = re.compile(r"(?P<scheme>https?://)(?P<host>localhost|127\.0\.0\.1)(?P<port>:\d+)?", re.IGNORECASE)
 LOCAL_HOST_PATTERN = re.compile(r"(?<![\w.-])(?P<host>localhost|127\.0\.0\.1)(?P<port>:\d+)?(?![\w.-])", re.IGNORECASE)
 GENERIC_USER_HOME_PATTERN = re.compile(r"(?i)^(?P<drive>[A-Z]:)[/\\]Users[/\\](?P<username>[^/\\]+)(?P<rest>(?:[/\\].*)?)$")
+USER_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<prefix>\b(?:user(?:name)?|owner|account)\b\s*[:=]\s*[\"']?)(?P<value>[A-Za-z0-9._-]+)(?P<suffix>[\"']?)",
+    re.IGNORECASE,
+)
 
 
 def _normalize_slashes(value: str) -> str:
@@ -30,6 +35,15 @@ def _normalize_slashes(value: str) -> str:
 
 def _masked_text(text: str) -> str:
     return f"<masked-text:{len(text)} chars>"
+
+
+def _known_usernames(home: Path | None = None) -> set[str]:
+    candidates = {
+        (home or Path.home()).name,
+        os.environ.get("USERNAME", ""),
+        Path(os.environ.get("USERPROFILE", "")).name if os.environ.get("USERPROFILE") else "",
+    }
+    return {value.casefold() for value in candidates if value}
 
 
 def _sanitize_path(path_text: str, *, project_root: Path | None = None, home: Path | None = None) -> str:
@@ -70,9 +84,16 @@ def mask_share_safe_text(text: str, *, project_root: Path | None = None) -> str:
     def replace_path(match: re.Match[str]) -> str:
         return _sanitize_path(match.group("path"), project_root=project_root)
 
+    def replace_user_assignment(match: re.Match[str]) -> str:
+        value = match.group("value")
+        if value.casefold() not in _known_usernames():
+            return match.group(0)
+        return f"{match.group('prefix')}<user-name>{match.group('suffix')}"
+
     masked = LOCAL_HOST_URL_PATTERN.sub(replace_url, text)
     masked = LOCAL_HOST_PATTERN.sub(replace_host, masked)
-    return WINDOWS_PATH_PATTERN.sub(replace_path, masked)
+    masked = WINDOWS_PATH_PATTERN.sub(replace_path, masked)
+    return USER_ASSIGNMENT_PATTERN.sub(replace_user_assignment, masked)
 
 
 def sanitize_for_sharing(

--- a/codex-dictation/codex_share_safe.py
+++ b/codex-dictation/codex_share_safe.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TEXT_KEYS_TO_MASK = {
+    "text",
+    "input_text",
+    "output_text",
+    "selection_text",
+    "source_text",
+    "prompt",
+    "raw_text",
+    "transcript",
+}
+WINDOWS_PATH_PATTERN = re.compile(r"(?P<path>(?<![A-Za-z])(?:[A-Za-z]:[\\/]|\\\\)[^\s\"'<>|]+)")
+LOCAL_HOST_URL_PATTERN = re.compile(r"(?P<scheme>https?://)(?P<host>localhost|127\.0\.0\.1)(?P<port>:\d+)?", re.IGNORECASE)
+LOCAL_HOST_PATTERN = re.compile(r"(?<![\w.-])(?P<host>localhost|127\.0\.0\.1)(?P<port>:\d+)?(?![\w.-])", re.IGNORECASE)
+GENERIC_USER_HOME_PATTERN = re.compile(r"(?i)^(?P<drive>[A-Z]:)[/\\]Users[/\\](?P<username>[^/\\]+)(?P<rest>(?:[/\\].*)?)$")
+
+
+def _normalize_slashes(value: str) -> str:
+    return value.replace("\\", "/")
+
+
+def _masked_text(text: str) -> str:
+    return f"<masked-text:{len(text)} chars>"
+
+
+def _sanitize_path(path_text: str, *, project_root: Path | None = None, home: Path | None = None) -> str:
+    candidate = Path(path_text)
+    root = (project_root or PROJECT_ROOT).resolve()
+    resolved_home = (home or Path.home()).resolve()
+    try:
+        relative = candidate.resolve(strict=False).relative_to(root)
+        return relative.as_posix()
+    except ValueError:
+        pass
+    try:
+        relative = candidate.resolve(strict=False).relative_to(resolved_home)
+        return f"<user-home>/{relative.as_posix()}" if relative.parts else "<user-home>"
+    except ValueError:
+        pass
+    normalized = _normalize_slashes(path_text)
+    generic_match = GENERIC_USER_HOME_PATTERN.match(normalized)
+    if generic_match:
+        rest = generic_match.group("rest").lstrip("/\\")
+        return f"<user-home>/{rest.replace('\\', '/')}" if rest else "<user-home>"
+    return candidate.name or "<abs-path>"
+
+
+def mask_share_safe_text(text: str, *, project_root: Path | None = None) -> str:
+    if not text:
+        return text
+
+    def replace_url(match: re.Match[str]) -> str:
+        scheme = match.group("scheme")
+        port = match.group("port") or ""
+        return f"{scheme}<local-host>{port}"
+
+    def replace_host(match: re.Match[str]) -> str:
+        port = match.group("port") or ""
+        return f"<local-host>{port}"
+
+    def replace_path(match: re.Match[str]) -> str:
+        return _sanitize_path(match.group("path"), project_root=project_root)
+
+    masked = LOCAL_HOST_URL_PATTERN.sub(replace_url, text)
+    masked = LOCAL_HOST_PATTERN.sub(replace_host, masked)
+    return WINDOWS_PATH_PATTERN.sub(replace_path, masked)
+
+
+def sanitize_for_sharing(
+    value: Any,
+    *,
+    project_root: Path | None = None,
+    mask_text_fields: bool = False,
+    current_key: str = "",
+) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: sanitize_for_sharing(
+                item,
+                project_root=project_root,
+                mask_text_fields=mask_text_fields,
+                current_key=str(key),
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            sanitize_for_sharing(
+                item,
+                project_root=project_root,
+                mask_text_fields=mask_text_fields,
+                current_key=current_key,
+            )
+            for item in value
+        ]
+    if isinstance(value, str):
+        if mask_text_fields and current_key.lower() in TEXT_KEYS_TO_MASK:
+            return _masked_text(value)
+        return mask_share_safe_text(value, project_root=project_root)
+    return value
+
+
+def render_share_safe_text(text: str, *, project_root: Path | None = None) -> str:
+    stripped = text.lstrip()
+    if stripped.startswith("{") or stripped.startswith("["):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return mask_share_safe_text(text, project_root=project_root)
+        return json.dumps(
+            sanitize_for_sharing(payload, project_root=project_root),
+            ensure_ascii=False,
+            indent=2,
+        )
+    return mask_share_safe_text(text, project_root=project_root)
+
+
+def write_share_safe_json(
+    payload: Any,
+    output_path: Path,
+    *,
+    project_root: Path | None = None,
+    mask_text_fields: bool = False,
+) -> Path:
+    sanitized = sanitize_for_sharing(
+        payload,
+        project_root=project_root,
+        mask_text_fields=mask_text_fields,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(sanitized, ensure_ascii=False, indent=2), encoding="utf-8")
+    return output_path
+
+
+def export_share_safe_file(
+    input_path: Path,
+    output_path: Path | None = None,
+    *,
+    project_root: Path | None = None,
+    mask_text_fields: bool = False,
+) -> Path:
+    destination = output_path or input_path.with_name(f"{input_path.stem}.share-safe{input_path.suffix}")
+    original = input_path.read_text(encoding="utf-8")
+    stripped = original.lstrip()
+    if stripped.startswith("{") or stripped.startswith("["):
+        try:
+            payload = json.loads(original)
+        except json.JSONDecodeError:
+            destination.write_text(mask_share_safe_text(original, project_root=project_root), encoding="utf-8")
+            return destination
+        return write_share_safe_json(
+            payload,
+            destination,
+            project_root=project_root,
+            mask_text_fields=mask_text_fields,
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(mask_share_safe_text(original, project_root=project_root), encoding="utf-8")
+    return destination
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="로그/결과물을 공유용으로 마스킹합니다.")
+    parser.add_argument("--input", type=Path, required=True, help="원본 파일 경로")
+    parser.add_argument("--output", type=Path, help="출력 파일 경로")
+    parser.add_argument("--mask-text", action="store_true", help="text/prompt 계열 문자열 값을 추가로 마스킹")
+    args = parser.parse_args()
+
+    output = export_share_safe_file(
+        args.input,
+        args.output,
+        project_root=PROJECT_ROOT,
+        mask_text_fields=args.mask_text,
+    )
+    print(output.as_posix())
+
+
+if __name__ == "__main__":
+    main()

--- a/codex-dictation/codex_share_safe.py
+++ b/codex-dictation/codex_share_safe.py
@@ -46,6 +46,14 @@ def _known_usernames(home: Path | None = None) -> set[str]:
     return {value.casefold() for value in candidates if value}
 
 
+def _mask_known_usernames(text: str, *, home: Path | None = None) -> str:
+    masked = text
+    for username in sorted(_known_usernames(home), key=len, reverse=True):
+        pattern = re.compile(rf"(?<![\w.-]){re.escape(username)}(?![\w.-])", re.IGNORECASE)
+        masked = pattern.sub("<user-name>", masked)
+    return masked
+
+
 def _sanitize_path(path_text: str, *, project_root: Path | None = None, home: Path | None = None) -> str:
     candidate = Path(path_text)
     root = (project_root or PROJECT_ROOT).resolve()
@@ -93,7 +101,8 @@ def mask_share_safe_text(text: str, *, project_root: Path | None = None) -> str:
     masked = LOCAL_HOST_URL_PATTERN.sub(replace_url, text)
     masked = LOCAL_HOST_PATTERN.sub(replace_host, masked)
     masked = WINDOWS_PATH_PATTERN.sub(replace_path, masked)
-    return USER_ASSIGNMENT_PATTERN.sub(replace_user_assignment, masked)
+    masked = USER_ASSIGNMENT_PATTERN.sub(replace_user_assignment, masked)
+    return _mask_known_usernames(masked)
 
 
 def sanitize_for_sharing(

--- a/codex-dictation/tests/test_share_safe.py
+++ b/codex-dictation/tests/test_share_safe.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+if str(PROJECT_DIR) not in sys.path:
+    sys.path.insert(0, str(PROJECT_DIR))
+
+from codex_share_safe import export_share_safe_file, mask_share_safe_text, sanitize_for_sharing  # noqa: E402
+
+
+class ShareSafeTextTests(unittest.TestCase):
+    def test_masks_home_path_and_local_host(self):
+        text = r"Open C:\Users\ParkJaeHong\AppData\Local\CodexDictation\codex_dictation.log via http://127.0.0.1:11434"
+        masked = mask_share_safe_text(text)
+        self.assertIn("<user-home>/AppData/Local/CodexDictation/codex_dictation.log", masked)
+        self.assertIn("http://<local-host>:11434", masked)
+        self.assertNotIn("ParkJaeHong", masked)
+        self.assertNotIn("127.0.0.1", masked)
+
+    def test_prefers_project_relative_path(self):
+        sample = PROJECT_DIR / "README.md"
+        masked = mask_share_safe_text(str(sample), project_root=PROJECT_DIR.parent)
+        self.assertEqual(masked, "codex-dictation/README.md")
+
+
+class ShareSafeJsonTests(unittest.TestCase):
+    def test_can_mask_text_fields_optionally(self):
+        payload = {
+            "url": "http://localhost:11434",
+            "text": "비밀 문장입니다",
+            "path": r"C:\Users\ParkJaeHong\secret.txt",
+        }
+        masked = sanitize_for_sharing(payload, mask_text_fields=True)
+        self.assertEqual(masked["text"], "<masked-text:8 chars>")
+        self.assertEqual(masked["url"], "http://<local-host>:11434")
+        self.assertEqual(masked["path"], "<user-home>/secret.txt")
+
+    def test_exports_plain_text_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_dir = Path(tmp_dir)
+            source = temp_dir / "sample.log"
+            output = temp_dir / "sample.share-safe.log"
+            source.write_text(r"host=localhost path=C:\Users\ParkJaeHong\sample.txt", encoding="utf-8")
+            export_share_safe_file(source, output)
+            masked = output.read_text(encoding="utf-8")
+            self.assertIn("host=<local-host>", masked)
+            self.assertIn("path=<user-home>/sample.txt", masked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex-dictation/tests/test_share_safe.py
+++ b/codex-dictation/tests/test_share_safe.py
@@ -22,6 +22,13 @@ class ShareSafeTextTests(unittest.TestCase):
         self.assertNotIn("ParkJaeHong", masked)
         self.assertNotIn("127.0.0.1", masked)
 
+    def test_masks_plain_username_assignments(self):
+        text = "user=ParkJaeHong username:\"ParkJaeHong\" owner=someone-else"
+        masked = mask_share_safe_text(text)
+        self.assertIn("user=<user-name>", masked)
+        self.assertIn('username:"<user-name>"', masked)
+        self.assertIn("owner=someone-else", masked)
+
     def test_prefers_project_relative_path(self):
         sample = PROJECT_DIR / "README.md"
         masked = mask_share_safe_text(str(sample), project_root=PROJECT_DIR.parent)

--- a/codex-dictation/tests/test_share_safe.py
+++ b/codex-dictation/tests/test_share_safe.py
@@ -29,6 +29,12 @@ class ShareSafeTextTests(unittest.TestCase):
         self.assertIn('username:"<user-name>"', masked)
         self.assertIn("owner=someone-else", masked)
 
+    def test_masks_standalone_known_username(self):
+        text = "owner ParkJaeHong shared the log from localhost"
+        masked = mask_share_safe_text(text)
+        self.assertIn("owner <user-name> shared the log from <local-host>", masked)
+        self.assertNotIn("ParkJaeHong", masked)
+
     def test_prefers_project_relative_path(self):
         sample = PROJECT_DIR / "README.md"
         masked = mask_share_safe_text(str(sample), project_root=PROJECT_DIR.parent)

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -9,6 +9,8 @@
   - RTX 4060 기준 실험 결과 요약 문서
 - `results_sovits_realtime.json`
   - 벤치마크 결과 원본 데이터
+- `results_sovits_realtime.share.json`
+  - 공유용으로 경로/로컬 호스트 정보를 마스킹한 결과 복사본
 
 현재 정리된 결론:
 - 워밍업 이후 기준으로는 `거의 실시간`에 가까운 결과
@@ -18,4 +20,10 @@
 
 ```powershell
 .venv\Scripts\python.exe experiments\benchmark_sovits_realtime.py
+```
+
+공유용 로그/결과 마스킹:
+
+```powershell
+.venv\Scripts\python.exe codex-dictation\codex_share_safe.py --input experiments\results_sovits_realtime.json --output experiments\results_sovits_realtime.share.json
 ```

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -8,9 +8,9 @@
 - `sovits_realtime_report.md`
   - RTX 4060 기준 실험 결과 요약 문서
 - `results_sovits_realtime.json`
-  - 벤치마크 결과 원본 데이터
+  - 체크인된 벤치마크 결과 원본 샘플
 - `results_sovits_realtime.share.json`
-  - 공유용으로 경로/로컬 호스트 정보를 마스킹한 결과 복사본
+  - 체크인된 공유용 마스킹 결과 샘플
 
 현재 정리된 결론:
 - 워밍업 이후 기준으로는 `거의 실시간`에 가까운 결과
@@ -22,8 +22,10 @@
 .venv\Scripts\python.exe experiments\benchmark_sovits_realtime.py
 ```
 
+실행 결과는 작업 트리를 더럽히지 않도록 `outputs/sovits-realtime/` 아래에 생성됩니다.
+
 공유용 로그/결과 마스킹:
 
 ```powershell
-.venv\Scripts\python.exe codex-dictation\codex_share_safe.py --input experiments\results_sovits_realtime.json --output experiments\results_sovits_realtime.share.json
+.venv\Scripts\python.exe codex-dictation\codex_share_safe.py --input outputs\sovits-realtime\results_sovits_realtime.json --output outputs\sovits-realtime\results_sovits_realtime.share.json
 ```

--- a/experiments/benchmark_sovits_realtime.py
+++ b/experiments/benchmark_sovits_realtime.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import statistics
+import sys
 import time
 from pathlib import Path
 
@@ -16,11 +17,18 @@ from so_vits_svc_fork.inference.core import RealtimeVC2, Svc
 
 
 ROOT = Path(__file__).resolve().parents[1]
+CODEX_DICTATION_DIR = ROOT / "codex-dictation"
+if str(CODEX_DICTATION_DIR) not in sys.path:
+    sys.path.insert(0, str(CODEX_DICTATION_DIR))
+
+from codex_share_safe import write_share_safe_json
+
 MODEL_PATH = ROOT / "models" / "pinkie" / "G_166400.pth"
 CONFIG_PATH = ROOT / "models" / "pinkie" / "config.json"
 SOURCE_DIR = ROOT / "external" / "so-vits-svc-fork" / "tests" / "dataset_raw" / "test"
 GENERATED_DIR = ROOT / "inputs"
 RESULT_PATH = ROOT / "experiments" / "results_sovits_realtime.json"
+SHARE_SAFE_RESULT_PATH = ROOT / "experiments" / "results_sovits_realtime.share.json"
 OUTPUT_DIR = ROOT / "outputs"
 
 
@@ -222,6 +230,7 @@ def main() -> None:
         "streaming_realtimevc2_after_warmup": streaming_results,
     }
     RESULT_PATH.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    write_share_safe_json(result, SHARE_SAFE_RESULT_PATH, project_root=ROOT)
     print(json.dumps(result, indent=2))
 
 

--- a/experiments/benchmark_sovits_realtime.py
+++ b/experiments/benchmark_sovits_realtime.py
@@ -27,9 +27,10 @@ MODEL_PATH = ROOT / "models" / "pinkie" / "G_166400.pth"
 CONFIG_PATH = ROOT / "models" / "pinkie" / "config.json"
 SOURCE_DIR = ROOT / "external" / "so-vits-svc-fork" / "tests" / "dataset_raw" / "test"
 GENERATED_DIR = ROOT / "inputs"
-RESULT_PATH = ROOT / "experiments" / "results_sovits_realtime.json"
-SHARE_SAFE_RESULT_PATH = ROOT / "experiments" / "results_sovits_realtime.share.json"
 OUTPUT_DIR = ROOT / "outputs"
+BENCHMARK_OUTPUT_DIR = OUTPUT_DIR / "sovits-realtime"
+RESULT_PATH = BENCHMARK_OUTPUT_DIR / "results_sovits_realtime.json"
+SHARE_SAFE_RESULT_PATH = BENCHMARK_OUTPUT_DIR / "results_sovits_realtime.share.json"
 
 
 def display_path(path: Path) -> str:
@@ -213,8 +214,7 @@ def main() -> None:
                 }
             )
 
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    RESULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BENCHMARK_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     result = {
         "environment": {
             "torch_version": torch.__version__,
@@ -231,6 +231,8 @@ def main() -> None:
     }
     RESULT_PATH.write_text(json.dumps(result, indent=2), encoding="utf-8")
     write_share_safe_json(result, SHARE_SAFE_RESULT_PATH, project_root=ROOT)
+    print(f"result_path={display_path(RESULT_PATH)}")
+    print(f"share_safe_result_path={display_path(SHARE_SAFE_RESULT_PATH)}")
     print(json.dumps(result, indent=2))
 
 

--- a/experiments/results_sovits_realtime.share.json
+++ b/experiments/results_sovits_realtime.share.json
@@ -1,0 +1,64 @@
+{
+  "environment": {
+    "torch_version": "2.9.1+cu128",
+    "cuda_version": "12.8",
+    "cuda_available": true,
+    "device_name": "NVIDIA GeForce RTX 4060",
+    "model_path": "models/pinkie/G_166400.pth",
+    "config_path": "models/pinkie/config.json",
+    "speaker": "Pinkie {neutral}",
+    "sample_rate": 44100
+  },
+  "offline_after_warmup": [
+    {
+      "input_seconds": 1.0,
+      "output_seconds": 1.0,
+      "elapsed_seconds": 0.5134313000016846,
+      "rtf": 0.5134313000016846,
+      "input_path": "inputs/benchmark_1.0s.wav"
+    },
+    {
+      "input_seconds": 3.0,
+      "output_seconds": 3.0,
+      "elapsed_seconds": 0.673982000000251,
+      "rtf": 0.22466066666675033,
+      "input_path": "inputs/benchmark_3.0s.wav"
+    },
+    {
+      "input_seconds": 6.0,
+      "output_seconds": 6.0,
+      "elapsed_seconds": 0.6966969999994035,
+      "rtf": 0.11611616666656725,
+      "input_path": "inputs/benchmark_6.0s.wav"
+    },
+    {
+      "input_seconds": 12.0,
+      "output_seconds": 12.0,
+      "elapsed_seconds": 1.0854241999986698,
+      "rtf": 0.09045201666655582,
+      "input_path": "inputs/benchmark_12.0s.wav"
+    }
+  ],
+  "streaming_realtimevc2_after_warmup": [
+    {
+      "input_path": "inputs/benchmark_12.0s.wav",
+      "block_seconds": 0.5,
+      "blocks": 24,
+      "mean_rtf": 0.10556558333367623,
+      "median_rtf": 0.021002000001317356,
+      "p95_rtf": 0.6601003099989596,
+      "max_rtf": 1.3040532000013627,
+      "blocks_over_1x": 1
+    },
+    {
+      "input_path": "inputs/benchmark_12.0s.wav",
+      "block_seconds": 1.0,
+      "blocks": 12,
+      "mean_rtf": 0.0897907416668507,
+      "median_rtf": 0.01163540000015928,
+      "p95_rtf": 0.4654135950004272,
+      "max_rtf": 0.6355039000009128,
+      "blocks_over_1x": 0
+    }
+  ]
+}


### PR DESCRIPTION
## 요약
- 공유용 로그/결과 파일을 만들 수 있는 마스킹 유틸을 추가했습니다.
- 경로, 사용자명, 로컬 호스트 정보가 섞인 텍스트/JSON을 공유용 복사본으로 안전하게 내보낼 수 있습니다.
- `experiments` 결과와 `codex-dictation` 런타임 산출물 모두 같은 흐름으로 사용할 수 있게 정리했습니다.

## 변경 내용
- 공유용 마스킹 유틸 `codex_share_safe.py` 추가
- 런타임 산출물 내보내기 헬퍼 추가
- 벤치마크 스크립트에서 share-safe 결과 JSON을 함께 생성하도록 연결
- README 문서와 테스트 추가

## 검증
- `python -m py_compile codex-dictation/codex_share_safe.py codex-dictation/codex_dictation_utils.py experiments/benchmark_sovits_realtime.py`
- `python -m unittest discover -s codex-dictation/tests -v`

Closes #42