### PR TITLE
[chore] #66 codex-dictation 릴리즈 전 테스트 실패 정리

### DIFF
--- a/codex-dictation/README.md
+++ b/codex-dictation/README.md
@@ -198,6 +198,12 @@ codex-dictation\run_codex_terminal.bat
 .venv\Scripts\python.exe codex-dictation\codex_dictation.py --transcribe-file some_audio.wav --model tiny --language ko
 ```
 
+릴리즈 전 기본 검증:
+
+```powershell
+.venv\Scripts\python.exe -m unittest discover -s codex-dictation\tests -v
+```
+
 ## 메모
 
 - 기본 백엔드는 `faster-whisper`라서 로컬에서 무료로 돌 수 있습니다.

--- a/codex-dictation/tests/test_always_listen_regressions.py
+++ b/codex-dictation/tests/test_always_listen_regressions.py
@@ -75,6 +75,9 @@ class _RuntimeHarness(AppRuntimeMixin):
         self.emitted.append(text)
         return True
 
+    def refresh_history_browser(self):
+        pass
+
 
 class _NullText:
     def insert(self, *_args, **_kwargs):


### PR DESCRIPTION
## 작업 내용\n- 	est_poll_preserves_capture_order_for_back_to_back_segments 실패 수정\n- 최신 런타임 구조에 맞게 테스트 하네스 보강\n- 릴리즈 전 기본 검증 명령을 README에 추가\n\n## 검증\n- .venv\\Scripts\\python.exe -m unittest discover -s codex-dictation\\tests -v\n\n## 비고\n- 문서와 테스트 정리만 포함합니다.