### PR TITLE
[chore] #65 codex-dictation 첫 실행 안내와 진단 경험 보강

### DIFF
--- a/codex-dictation/README.md
+++ b/codex-dictation/README.md
@@ -81,6 +81,21 @@ Codex 터미널만 빠르게 열기:
 codex-dictation\run_codex_terminal.bat
 ```
 
+## 첫 실행 체크리스트
+
+처음 실행할 때는 아래 순서로 확인하는 것이 가장 빠릅니다.
+
+1. 앱이 켜지면 상단 제목에 버전이 보이는지 확인합니다.
+2. `Doctor` 버튼 또는 `--doctor` 명령으로 현재 환경을 점검합니다.
+3. `Input Device`가 실제 마이크로 잡혀 있는지 확인합니다.
+4. 항상 듣기나 수동 녹음을 한 번 짧게 실행해 로그에 전사 결과가 남는지 확인합니다.
+5. 로그와 설정 파일 위치는 `%LOCALAPPDATA%\CodexDictation\` 아래를 먼저 봅니다.
+
+대표적으로 확인할 파일:
+- 설정: `%LOCALAPPDATA%\CodexDictation\codex_dictation.settings.json`
+- 기록: `%LOCALAPPDATA%\CodexDictation\codex_dictation.history.jsonl`
+- 로그: `%LOCALAPPDATA%\CodexDictation\codex_dictation.log`
+
 ## AutoHotkey 런처
 
 `codex-dictation\launch_codex_dictation.ahk`를 AutoHotkey v2로 실행하면 전역 단축키를 쓸 수 있습니다.
@@ -186,6 +201,12 @@ codex-dictation\run_codex_terminal.bat
 
 ## 점검
 
+버전 확인:
+
+```powershell
+.venv\Scripts\python.exe codex-dictation\codex_dictation.py --version
+```
+
 환경 점검:
 
 ```powershell
@@ -197,6 +218,20 @@ codex-dictation\run_codex_terminal.bat
 ```powershell
 .venv\Scripts\python.exe codex-dictation\codex_dictation.py --transcribe-file some_audio.wav --model tiny --language ko
 ```
+
+## 문제 해결
+
+- 앱이 안 켜지면
+  - `codex-dictation\run_codex_dictation.bat`로 다시 실행해 보고, `%LOCALAPPDATA%\CodexDictation\codex_dictation.log`를 확인합니다.
+- 마이크가 안 잡히면
+  - `--doctor` 출력의 `Input devices` 목록과 앱 설정의 `Input Device`가 맞는지 먼저 확인합니다.
+- 전사가 안 되면
+  - Whisper 모델이 처음 다운로드 중인지, 또는 로그에 `No speech detected`가 반복되는지 봅니다.
+- 입력창에 텍스트가 안 들어가면
+  - 현재 포커스된 창이 실제 텍스트 입력 상태인지, `Output Mode`가 맞는지, 붙여넣기 차단 앱인지 확인합니다.
+- 로그를 공유해야 하면
+  - 먼저 share-safe 출력으로 변환합니다.
+  - `python codex-dictation/codex_share_safe.py --input %LOCALAPPDATA%\CodexDictation\codex_dictation.log --output outputs\codex_dictation.log.share-safe`
 
 ## 메모
 

--- a/codex-dictation/codex_dictation.py
+++ b/codex-dictation/codex_dictation.py
@@ -8,7 +8,7 @@ from tkinter import ttk
 
 from codex_dictation_app import App
 from codex_dictation_diagnostics import doctor
-from codex_dictation_settings import APP_NAME, load_settings, normalize_language_value
+from codex_dictation_settings import APP_NAME, APP_VERSION, load_settings, normalize_language_value
 from codex_dictation_targeting import acquire_single_instance, fg_info
 from codex_dictation_transcription import transcribe_file
 from codex_dictation_utils import append_app_log
@@ -16,6 +16,7 @@ from codex_dictation_utils import append_app_log
 
 def main():
     parser = argparse.ArgumentParser(description=APP_NAME)
+    parser.add_argument("--version", action="version", version=f"{APP_NAME} {APP_VERSION}")
     parser.add_argument("--doctor", action="store_true")
     parser.add_argument("--transcribe-file", type=Path)
     parser.add_argument("--model", type=str)

--- a/codex-dictation/codex_dictation_app.py
+++ b/codex-dictation/codex_dictation_app.py
@@ -11,7 +11,7 @@ from codex_dictation_app_runtime import AppRuntimeMixin
 from codex_dictation_app_ui import AppUIMixin
 from codex_dictation_output_state import OutputState
 from codex_dictation_postedit import AICorrectionPrefetchState, OllamaPostEditor
-from codex_dictation_settings import APP_NAME, audio_preset_label, language_label, llm_profile_label, load_settings, save_settings
+from codex_dictation_settings import APP_TITLE, audio_preset_label, language_label, llm_profile_label, load_settings, save_settings
 from codex_dictation_targeting import WinInfo
 from codex_dictation_transcription import WhisperBackend
 
@@ -19,7 +19,7 @@ from codex_dictation_transcription import WhisperBackend
 class App(AppRuntimeMixin, AppActionsMixin, AppUIMixin):
     def __init__(self, root: tk.Tk, launch_target: WinInfo | None = None, show_window: bool = False):
         self.root = root
-        self.root.title(APP_NAME)
+        self.root.title(APP_TITLE)
         self.root.geometry("980x780")
         self.root.protocol("WM_DELETE_WINDOW", self.close)
         self.launch_target = launch_target

--- a/codex-dictation/codex_dictation_app_ui.py
+++ b/codex-dictation/codex_dictation_app_ui.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk
 
-from codex_dictation_settings import APP_NAME, AUDIO_PRESET_UI_LABELS, audio_preset_label
+from codex_dictation_settings import APP_NAME, APP_VERSION, AUDIO_PRESET_UI_LABELS, audio_preset_label
 
 
 class AppUIMixin:
@@ -14,14 +14,15 @@ class AppUIMixin:
         head.grid(row=0, column=0, sticky="ew")
         head.columnconfigure(1, weight=1)
         ttk.Label(head, text=APP_NAME, font=("Segoe UI", 18, "bold")).grid(row=0, column=0, sticky="w")
+        ttk.Label(head, text=f"v{APP_VERSION}", font=("Segoe UI", 10)).grid(row=1, column=0, sticky="w", pady=(2, 0))
         ttk.Label(head, textvariable=self.status, font=("Segoe UI", 10, "bold")).grid(row=0, column=1, sticky="e")
-        ttk.Label(head, textvariable=self.target).grid(row=1, column=0, columnspan=2, sticky="w", pady=(6, 0))
+        ttk.Label(head, textvariable=self.target).grid(row=2, column=0, columnspan=2, sticky="w", pady=(6, 0))
         ttk.Label(
             head,
             text="F7 항상 듣기, F8 수동 녹음, F9 마지막 문장, F10 출력 모드, F11 Enter 전환 | 음성 명령: 보내, 지워, 다 지워, 전체 비워, 다시 ..., 복사, 붙여넣기, 잘라, 취소, 되돌려, 자동/한국어/영어, 최대화/최소화/복원, 이스케이프/나가기, 일시정지/재생, 앞으로/뒤로 감기",
-        ).grid(row=2, column=0, columnspan=2, sticky="w", pady=(6, 0))
-        ttk.Label(head, textvariable=self.audio_status, font=("Consolas", 9)).grid(row=3, column=0, columnspan=2, sticky="w", pady=(8, 0))
-        ttk.Label(head, textvariable=self.llm_status, font=("Consolas", 9)).grid(row=4, column=0, columnspan=2, sticky="w", pady=(4, 0))
+        ).grid(row=3, column=0, columnspan=2, sticky="w", pady=(6, 0))
+        ttk.Label(head, textvariable=self.audio_status, font=("Consolas", 9)).grid(row=4, column=0, columnspan=2, sticky="w", pady=(8, 0))
+        ttk.Label(head, textvariable=self.llm_status, font=("Consolas", 9)).grid(row=5, column=0, columnspan=2, sticky="w", pady=(4, 0))
         top = ttk.Frame(self.root, padding=(12, 0, 12, 0))
         top.grid(row=1, column=0, sticky="nsew")
         top.columnconfigure((0, 1), weight=1)

--- a/codex-dictation/codex_dictation_diagnostics.py
+++ b/codex-dictation/codex_dictation_diagnostics.py
@@ -5,6 +5,7 @@ import sys
 from codex_dictation_audio import get_input_devices
 from codex_dictation_settings import (
     APP_NAME,
+    APP_VERSION,
     DATA_ROOT,
     HISTORY_PATH,
     LEGACY_HISTORY_PATH,
@@ -38,6 +39,7 @@ def doctor(settings: Settings | None = None) -> str:
     lines = [
         f"{APP_NAME} doctor",
         "-" * 40,
+        f"Version: {APP_VERSION}",
         f"Python: {sys.version.split()[0]}",
         f"Data root: {display_path(DATA_ROOT, base=DATA_ROOT.parent)}",
         f"Settings: {display_path(SETTINGS_PATH)}",

--- a/codex-dictation/codex_dictation_settings.py
+++ b/codex-dictation/codex_dictation_settings.py
@@ -24,6 +24,8 @@ def _user_data_root() -> Path:
 
 
 APP_NAME = "Codex Dictation"
+APP_VERSION = "0.1.0-beta.1"
+APP_TITLE = f"{APP_NAME} v{APP_VERSION}"
 LEGACY_ROOT = _legacy_runtime_root()
 DATA_ROOT = _user_data_root()
 ROOT = DATA_ROOT


### PR DESCRIPTION
## 작업 내용
- 앱 제목, 헤더, doctor 출력, CLI에서 버전 확인이 가능하도록 보강
- 첫 실행 체크리스트와 문제 해결 문서를 codex-dictation README에 추가
- 외부 사용자가 설정/로그/기록 파일 위치를 바로 찾을 수 있게 안내 정리

## 검증
- `C:\Users\ParkJaeHong\Desktop\실험\exp\.venv\Scripts\python.exe codex-dictation\codex_dictation.py --version`
- `C:\Users\ParkJaeHong\Desktop\실험\exp\.venv\Scripts\python.exe codex-dictation\codex_dictation.py --doctor`
- `C:\Users\ParkJaeHong\Desktop\실험\exp\.venv\Scripts\python.exe -m py_compile codex-dictation\codex_dictation.py codex-dictation\codex_dictation_app.py codex-dictation\codex_dictation_app_ui.py codex-dictation\codex_dictation_diagnostics.py codex-dictation\codex_dictation_settings.py`
