### PR TITLE
[chore] #64 codex-dictation 릴리즈 패키지 구조 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyc
 codex-dictation/build/
 codex-dictation/dist/
+codex-dictation/release/
 codex-dictation/codex_dictation.history.jsonl
 codex-dictation/codex_dictation.log
 tmp_*.txt

--- a/codex-dictation/README.md
+++ b/codex-dictation/README.md
@@ -61,6 +61,44 @@ codex-dictation\dist\CodexDictation.exe
 - 첫 실행 시 `faster-whisper` 모델이 PC에 없다면 모델 다운로드는 여전히 한 번 필요합니다.
 - 전역 핫키는 기존처럼 `tools\AutoHotkey` 또는 `run_codex_hotkeys.bat` 흐름을 같이 쓰는 것이 가장 편합니다.
 
+## 릴리즈 패키지 만들기
+
+외부 배포용으로는 `exe`만 따로 주기보다, 핫키 런처와 `AutoHotkey` 엔진까지 함께 묶은 패키지를 만드는 편이 좋습니다.
+이 스크립트는 `worktree`에서 실행하더라도 연결된 원본 저장소의 `.venv`를 찾아 빌드를 시도합니다. 필요하면 `-PythonPath`로 사용할 Python을 직접 지정할 수 있습니다.
+
+```powershell
+codex-dictation\package_codex_dictation_release.ps1
+```
+
+완료되면 아래 구조가 생성됩니다.
+
+```text
+codex-dictation\release\CodexDictation-win64\
+  codex-dictation\
+    dist\CodexDictation.exe
+    README.md
+    launch_codex_dictation.ahk
+    run_codex_dictation.bat
+    run_codex_hotkeys.bat
+  tools\AutoHotkey\
+```
+
+같은 위치에 `CodexDictation-win64.zip`도 함께 만들어지므로 GitHub Releases 자산으로 올리기 좋습니다.
+
+배포 패키지 기준 권장 실행 순서:
+1. `CodexDictation-win64.zip`을 원하는 폴더에 압축 해제
+2. `codex-dictation\run_codex_hotkeys.bat` 실행
+3. 이후 `F1`로 앱 실행 또는 최소화
+4. 설정 확인이 필요하면 `F2`
+
+핫키 없이 앱만 먼저 확인하고 싶다면:
+1. `codex-dictation\run_codex_dictation.bat`로 앱 본체만 직접 실행
+
+메모:
+- 배포 패키지는 `exe`, 배치 런처, `AutoHotkey` 엔진만 포함하므로 Python 설치가 없어도 실행할 수 있습니다.
+- 첫 실행 시 `faster-whisper` 모델 다운로드는 여전히 한 번 필요할 수 있습니다.
+- GitHub Releases에는 `CodexDictation-win64.zip` 하나만 올려도 사용자가 필요한 파일을 한 번에 받을 수 있습니다.
+
 ## 실행
 
 ```powershell

--- a/codex-dictation/build_codex_dictation_exe.ps1
+++ b/codex-dictation/build_codex_dictation_exe.ps1
@@ -1,3 +1,7 @@
+param(
+    [string]$PythonPath = ""
+)
+
 $ErrorActionPreference = "Stop"
 
 function Find-PythonInAncestorVenv {
@@ -23,11 +27,55 @@ function Find-PythonInAncestorVenv {
     return $null
 }
 
+function Find-PythonInGitCommonDirVenv {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StartDirectory
+    )
+
+    $gitCommonDir = $null
+    try {
+        $gitCommonDir = (& git -C $StartDirectory rev-parse --path-format=absolute --git-common-dir 2>$null | Select-Object -First 1).Trim()
+    } catch {
+        return $null
+    }
+
+    if (-not $gitCommonDir) {
+        return $null
+    }
+
+    $gitCommonDirPath = $gitCommonDir
+    if (-not (Test-Path $gitCommonDirPath)) {
+        return $null
+    }
+
+    $repoRoot = Split-Path $gitCommonDirPath -Parent
+    if (-not $repoRoot) {
+        return $null
+    }
+
+    $candidate = Join-Path $repoRoot ".venv\Scripts\python.exe"
+    if (Test-Path $candidate) {
+        return $candidate
+    }
+
+    return $null
+}
+
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$python = Find-PythonInAncestorVenv -StartDirectory $scriptDir
+$python = $PythonPath
+
+if ($python) {
+    $python = (Resolve-Path $python).Path
+} else {
+    $python = Find-PythonInAncestorVenv -StartDirectory $scriptDir
+    if (-not $python) {
+        $python = Find-PythonInGitCommonDirVenv -StartDirectory $scriptDir
+    }
+}
 
 if (-not $python) {
-    throw ".venv\Scripts\python.exe 를 찾지 못했습니다. 저장소 루트에서 가상환경을 먼저 준비해주세요."
+    throw ".venv\\Scripts\\python.exe 를 찾지 못했습니다. 저장소 루트 또는 연결된 worktree의 원본 저장소에서 가상환경을 먼저 준비하거나 -PythonPath로 직접 지정해주세요."
 }
 
 $buildRequirements = Join-Path $scriptDir "requirements-dictation-build.txt"

--- a/codex-dictation/package_codex_dictation_release.ps1
+++ b/codex-dictation/package_codex_dictation_release.ps1
@@ -1,0 +1,76 @@
+param(
+    [string]$PythonPath = "",
+    [switch]$SkipBuild,
+    [switch]$SkipZip
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path $scriptDir -Parent
+$buildScript = Join-Path $scriptDir "build_codex_dictation_exe.ps1"
+$exePath = Join-Path $scriptDir "dist\CodexDictation.exe"
+$releaseRoot = Join-Path $scriptDir "release"
+$packageName = "CodexDictation-win64"
+$packageRoot = Join-Path $releaseRoot $packageName
+$packageAppDir = Join-Path $packageRoot "codex-dictation"
+$packageToolsDir = Join-Path $packageRoot "tools"
+$packageZip = Join-Path $releaseRoot ($packageName + ".zip")
+$autoHotkeyDir = Join-Path $repoRoot "tools\AutoHotkey"
+
+if (-not $SkipBuild) {
+    if ($PythonPath) {
+        & $buildScript -PythonPath $PythonPath
+    } else {
+        & $buildScript
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "단일 실행 파일 빌드에 실패했습니다."
+    }
+}
+
+if (-not (Test-Path $exePath)) {
+    throw "릴리즈 패키지를 만들려면 먼저 실행 파일이 필요합니다: $exePath"
+}
+
+if (-not (Test-Path $autoHotkeyDir)) {
+    throw "릴리즈 패키지를 만들려면 AutoHotkey 엔진이 필요합니다: $autoHotkeyDir"
+}
+
+if (Test-Path $packageRoot) {
+    Remove-Item -LiteralPath $packageRoot -Recurse -Force
+}
+if (-not (Test-Path $releaseRoot)) {
+    New-Item -ItemType Directory -Path $releaseRoot | Out-Null
+}
+
+New-Item -ItemType Directory -Path (Join-Path $packageAppDir "dist") -Force | Out-Null
+New-Item -ItemType Directory -Path $packageToolsDir -Force | Out-Null
+
+Copy-Item -LiteralPath $exePath -Destination (Join-Path $packageAppDir "dist\CodexDictation.exe")
+
+foreach ($relativePath in @(
+    "README.md",
+    "launch_codex_dictation.ahk",
+    "run_codex_dictation.bat",
+    "run_codex_hotkeys.bat"
+)) {
+    Copy-Item -LiteralPath (Join-Path $scriptDir $relativePath) -Destination (Join-Path $packageAppDir $relativePath)
+}
+
+Copy-Item -LiteralPath $autoHotkeyDir -Destination (Join-Path $packageToolsDir "AutoHotkey") -Recurse
+
+if (Test-Path $packageZip) {
+    Remove-Item -LiteralPath $packageZip -Force
+}
+
+if (-not $SkipZip) {
+    Compress-Archive -Path $packageRoot -DestinationPath $packageZip -Force
+}
+
+Write-Host ""
+Write-Host "릴리즈 패키지 준비 완료:"
+Write-Host " - 폴더: $packageRoot"
+if (-not $SkipZip) {
+    Write-Host " - zip:   $packageZip"
+}


### PR DESCRIPTION
## 요약
- worktree에서도 원본 저장소의 `.venv`를 찾아 `exe` 빌드를 이어갈 수 있도록 빌드 스크립트를 보강했습니다.
- `exe`, 핫키 런처, AutoHotkey 엔진을 함께 묶는 릴리즈 패키지 스크립트를 추가했습니다.
- 배포 산출물 구조와 사용자 실행 순서를 `codex-dictation/README.md`에 정리했습니다.
- 생성된 `release/` 산출물은 Git 추적에서 제외했습니다.

## 검증
- `pwsh -File codex-dictation\package_codex_dictation_release.ps1`
- `pwsh -File codex-dictation\package_codex_dictation_release.ps1 -SkipBuild`

## 참고
- 해결 이슈: #64
