### PR TITLE
[codex] 회의 요약 도구 공용 데이터 모델 추가

### DIFF
--- a/meeting-summary-tool/src/meeting_summary_tool/models.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/models.py
@@ -1,4 +1,101 @@
-"""Shared data models for the meeting summary pipeline.
+"""Shared data models for the meeting summary pipeline."""
 
-Detailed models are added in a follow-up issue.
-"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class AudioInput:
+    """User-provided audio input and metadata."""
+
+    audio_path: Path
+    meeting_title: str | None = None
+    meeting_date: str | None = None
+    attendees: list[str] = field(default_factory=list)
+    notes: str | None = None
+    output_dir: Path | None = None
+
+
+@dataclass(slots=True)
+class TranscriptSegment:
+    """A single transcript segment."""
+
+    text: str
+    speaker: str | None = None
+    start_sec: float | None = None
+    end_sec: float | None = None
+    confidence: float | None = None
+
+    def as_text_line(self) -> str:
+        """Render a human-readable transcript line."""
+
+        prefix = f"{self.speaker}: " if self.speaker else ""
+        return f"{prefix}{self.text}".strip()
+
+
+@dataclass(slots=True)
+class TranscriptDocument:
+    """Normalized transcript output produced by STT."""
+
+    source_file: Path
+    segments: list[TranscriptSegment] = field(default_factory=list)
+    full_text: str = ""
+    language: str = "ko"
+    duration_sec: float | None = None
+    model_name: str | None = None
+    device: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def has_content(self) -> bool:
+        """Return whether the transcript contains usable text."""
+
+        return bool(self.full_text.strip() or self.segments)
+
+
+@dataclass(slots=True)
+class DecisionItem:
+    """A decision extracted from a meeting."""
+
+    text: str
+
+
+@dataclass(slots=True)
+class ActionItem:
+    """An action item extracted from a meeting."""
+
+    text: str
+    owner: str | None = None
+    due_date: str | None = None
+
+
+@dataclass(slots=True)
+class SummaryDocument:
+    """Structured summary output generated from a transcript."""
+
+    summary: str
+    decisions: list[DecisionItem] = field(default_factory=list)
+    action_items: list[ActionItem] = field(default_factory=list)
+    provider: str | None = None
+    model_name: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SavedArtifact:
+    """A file created by the pipeline."""
+
+    path: Path
+    kind: str
+
+
+@dataclass(slots=True)
+class PipelineResult:
+    """Combined pipeline result across transcript, summary, and saved files."""
+
+    audio_input: AudioInput
+    transcript: TranscriptDocument | None = None
+    summary: SummaryDocument | None = None
+    artifacts: list[SavedArtifact] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)


### PR DESCRIPTION
## 요약
회의 요약 도구에서 공통으로 사용할 내부 데이터 모델을 추가했습니다. 이번 변경에서는 오디오 입력, transcript, summary, action item, 생성 산출물을 코드 차원에서 다룰 수 있도록 dataclass 기반 구조를 정리했습니다.

## 사용자 영향
실행 기능이 크게 늘어난 것은 아니지만, 이제 CLI, STT, 출력기, 요약 백엔드가 같은 타입을 기준으로 연결될 수 있습니다. 후속 구현에서 임시 dict를 남발하지 않고 공통 모델을 공유할 수 있게 됐습니다.

## 수정 내용
- `meeting-summary-tool/src/meeting_summary_tool/models.py`에 공용 dataclass 모델을 추가했습니다.
- `AudioInput`, `TranscriptSegment`, `TranscriptDocument`, `DecisionItem`, `ActionItem`, `SummaryDocument`, `SavedArtifact`, `PipelineResult`를 정의했습니다.
- transcript가 실제 내용을 갖는지 확인하는 `has_content()` 같은 최소 보조 메서드도 포함했습니다.

## 확인
- `PYTHONPATH=meeting-summary-tool/src` 기준으로 모델 import를 확인했습니다.
- 간단한 인스턴스 생성과 `TranscriptDocument.has_content()` 호출을 확인했습니다.

Closes #87
