### PR TITLE
[codex] 회의 요약 도구 CLI 엔트리포인트 추가

### DIFF
--- a/meeting-summary-tool/src/meeting_summary_tool/cli.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/cli.py
@@ -2,18 +2,119 @@
 
 from __future__ import annotations
 
+import argparse
 from collections.abc import Sequence
+from pathlib import Path
+
+from meeting_summary_tool.models import AudioInput
+from meeting_summary_tool.pipeline import prepare_pipeline_run
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(
+        prog="meeting-summary-tool",
+        description="회의 오디오 파일 입력과 기본 실행 계획을 준비합니다.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="전사할 오디오 파일 경로",
+    )
+    parser.add_argument(
+        "--title",
+        help="회의 제목",
+    )
+    parser.add_argument(
+        "--date",
+        help="회의 날짜 (예: 2026-04-11)",
+    )
+    parser.add_argument(
+        "--attendees",
+        help="쉼표로 구분한 참석자 목록",
+    )
+    parser.add_argument(
+        "--notes",
+        help="추가 메모",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="결과 저장 디렉토리",
+    )
+    return parser
+
+
+def parse_attendees(raw_attendees: str | None) -> list[str]:
+    """Parse a comma-separated attendee list."""
+
+    if not raw_attendees:
+        return []
+    return [item.strip() for item in raw_attendees.split(",") if item.strip()]
+
+
+def build_audio_input_from_args(args: argparse.Namespace) -> AudioInput:
+    """Convert CLI arguments into the shared audio input model."""
+
+    audio_path = Path(args.input).expanduser().resolve()
+    if not audio_path.exists():
+        raise FileNotFoundError(f"입력 파일을 찾을 수 없습니다: {audio_path}")
+    if not audio_path.is_file():
+        raise ValueError(f"입력 경로가 파일이 아닙니다: {audio_path}")
+
+    output_dir = None
+    if args.output_dir:
+        output_dir = Path(args.output_dir).expanduser().resolve()
+
+    return AudioInput(
+        audio_path=audio_path,
+        meeting_title=args.title,
+        meeting_date=args.date,
+        attendees=parse_attendees(args.attendees),
+        notes=args.notes,
+        output_dir=output_dir,
+    )
+
+
+def _render_run_summary(audio_input: AudioInput) -> list[str]:
+    """Build a user-facing summary for the prepared run."""
+
+    lines = [
+        "meeting-summary-tool CLI 입력이 준비되었습니다.",
+        f"- 입력 파일: {audio_input.audio_path}",
+    ]
+    if audio_input.meeting_title:
+        lines.append(f"- 회의 제목: {audio_input.meeting_title}")
+    if audio_input.meeting_date:
+        lines.append(f"- 회의 날짜: {audio_input.meeting_date}")
+    if audio_input.attendees:
+        lines.append(f"- 참석자: {', '.join(audio_input.attendees)}")
+    if audio_input.output_dir:
+        lines.append(f"- 출력 디렉토리: {audio_input.output_dir}")
+    return lines
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the minimal CLI entrypoint.
+    """Run the CLI entrypoint."""
 
-    The full argument parser is added in a follow-up issue. For now this
-    function exists so the package can expose a stable entrypoint.
-    """
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
 
-    _ = argv
-    print("meeting-summary-tool CLI scaffold is ready.")
+    try:
+        audio_input = build_audio_input_from_args(args)
+    except (FileNotFoundError, ValueError) as exc:
+        parser.exit(status=2, message=f"{exc}\n")
+
+    prepared_run = prepare_pipeline_run(audio_input)
+
+    for line in _render_run_summary(prepared_run.audio_input):
+        print(line)
+    print(f"- 정규화된 출력 디렉토리: {prepared_run.output_dir}")
+    if prepared_run.warnings:
+        print("- 경고:")
+        for warning in prepared_run.warnings:
+            print(f"  - {warning}")
+    print("다음 단계로 STT / 요약 파이프라인을 연결하면 됩니다.")
     return 0
 
 

--- a/meeting-summary-tool/src/meeting_summary_tool/pipeline.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/pipeline.py
@@ -1,6 +1,39 @@
-"""Top-level pipeline orchestration placeholders."""
+"""Top-level pipeline orchestration helpers."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from meeting_summary_tool.config import resolve_default_output_dir
+from meeting_summary_tool.models import AudioInput
+
+
+@dataclass(slots=True)
+class PreparedPipelineRun:
+    """Normalized run plan prepared by the CLI layer."""
+
+    audio_input: AudioInput
+    output_dir: Path
+    warnings: list[str] = field(default_factory=list)
+
+
+def prepare_pipeline_run(audio_input: AudioInput) -> PreparedPipelineRun:
+    """Prepare a normalized run plan before the real pipeline is wired."""
+
+    output_dir = audio_input.output_dir or resolve_default_output_dir()
+    warnings: list[str] = []
+
+    if not audio_input.meeting_title:
+        warnings.append("회의 제목이 없어 파일명 기반 기본값을 사용하게 됩니다.")
+    if not audio_input.meeting_date:
+        warnings.append("회의 날짜가 없어 실행 시점 기반 기본값을 사용하게 됩니다.")
+
+    return PreparedPipelineRun(
+        audio_input=audio_input,
+        output_dir=output_dir,
+        warnings=warnings,
+    )
 
 
 def run_pipeline() -> None:


### PR DESCRIPTION
## 요약
회의 요약 도구의 CLI 엔트리포인트를 실제 인자 파싱 형태로 확장했습니다. 이번 변경에서는 오디오 입력 파일 경로, 제목, 날짜, 참석자, 메모, 출력 디렉토리를 받을 수 있게 했고, 입력 검증 후 기본 실행 계획을 출력하도록 구성했습니다.

## 사용자 영향
이제 `python -m meeting_summary_tool.cli`로 최소 실행 흐름을 확인할 수 있습니다. 아직 STT와 요약은 연결되지 않았지만, 입력 오류와 기본 출력 경로 정규화까지는 동작합니다.

## 수정 내용
- `meeting-summary-tool/src/meeting_summary_tool/cli.py`에 argparse 기반 인자 파싱을 추가했습니다.
- 입력 파일 존재 여부와 파일 타입을 검증하도록 했습니다.
- 참석자 문자열 파싱과 사용자 대상 실행 요약 출력을 추가했습니다.
- `meeting-summary-tool/src/meeting_summary_tool/pipeline.py`에 `PreparedPipelineRun`과 기본 실행 계획 준비 함수를 추가했습니다.

## 확인
- 임시 오디오 파일을 사용해 `python -m meeting_summary_tool.cli --input ...` 실행을 확인했습니다.
- 존재하지 않는 파일 입력 시 오류 메시지가 출력되는 것도 확인했습니다.

Closes #86
