### PR TITLE
[codex] 회의 요약 도구 요약 백엔드 정리

### DIFF
--- a/meeting-summary-tool/src/meeting_summary_tool/models.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/models.py
@@ -42,6 +42,7 @@ class TranscriptDocument:
     source_file: Path
     segments: list[TranscriptSegment] = field(default_factory=list)
     full_text: str = ""
+    speaker_map: dict[str, str] = field(default_factory=dict)
     language: str = "ko"
     duration_sec: float | None = None
     model_name: str | None = None
@@ -53,12 +54,27 @@ class TranscriptDocument:
 
         return bool(self.full_text.strip() or self.segments)
 
+    def iter_lines(self) -> list[str]:
+        """Render transcript content into line-oriented text."""
+
+        if self.segments:
+            return [segment.as_text_line() for segment in self.segments if segment.text.strip()]
+        if self.full_text:
+            return [line.strip() for line in self.full_text.splitlines() if line.strip()]
+        return []
+
+    def render_text(self) -> str:
+        """Render transcript content as a single text block."""
+
+        return "\n".join(self.iter_lines())
+
 
 @dataclass(slots=True)
 class DecisionItem:
     """A decision extracted from a meeting."""
 
     text: str
+    confidence: float | None = None
 
 
 @dataclass(slots=True)
@@ -66,6 +82,7 @@ class ActionItem:
     """An action item extracted from a meeting."""
 
     text: str
+    confidence: float | None = None
     owner: str | None = None
     due_date: str | None = None
 

--- a/meeting-summary-tool/src/meeting_summary_tool/summarize/backend.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/summarize/backend.py
@@ -20,13 +20,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Protocol, Sequence
 
+from meeting_summary_tool.models import ActionItem
+from meeting_summary_tool.models import DecisionItem
+from meeting_summary_tool.models import TranscriptDocument
+from meeting_summary_tool.models import TranscriptSegment
+
 __all__ = [
     "ActionItem",
     "DecisionItem",
     "PromptMessage",
     "SummaryBackend",
     "SummaryBackendConfig",
-    "SummaryItem",
     "SummaryPayload",
     "SummaryProvider",
     "SummaryRequest",
@@ -38,41 +42,6 @@ __all__ = [
     "OpenAISummaryProvider",
     "build_default_backend",
 ]
-
-
-@dataclass(slots=True)
-class TranscriptSegment:
-    """A single normalized transcript segment."""
-
-    speaker: str
-    text: str
-    start_sec: float | None = None
-    end_sec: float | None = None
-
-    def as_text(self) -> str:
-        prefix = f"{self.speaker}: " if self.speaker else ""
-        return f"{prefix}{self.text}".strip()
-
-
-@dataclass(slots=True)
-class TranscriptDocument:
-    """Normalized transcript input consumed by the summary backend."""
-
-    segments: list[TranscriptSegment] = field(default_factory=list)
-    transcript_text: str | None = None
-    speaker_map: dict[str, str] = field(default_factory=dict)
-    language: str = "ko"
-
-    def iter_lines(self) -> list[str]:
-        if self.segments:
-            return [segment.as_text() for segment in self.segments if segment.text.strip()]
-        if self.transcript_text:
-            return [line.strip() for line in self.transcript_text.splitlines() if line.strip()]
-        return []
-
-    def render_text(self) -> str:
-        lines = self.iter_lines()
-        return "\n".join(lines)
 
 
 @dataclass(slots=True)
@@ -89,27 +58,6 @@ class SummaryRequest:
     api_key: str | None = None
     output_dir: Path | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(slots=True)
-class SummaryItem:
-    """Base structure for structured summary items."""
-
-    text: str
-    confidence: float | None = None
-
-
-@dataclass(slots=True)
-class DecisionItem(SummaryItem):
-    """A meeting decision extracted from the transcript."""
-
-
-@dataclass(slots=True)
-class ActionItem(SummaryItem):
-    """A meeting action item extracted from the transcript."""
-
-    owner: str | None = None
-    due_date: str | None = None
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## 요약
회의 요약 도구의 요약 백엔드 골격을 공용 모델 기준으로 정리했습니다. 이미 들어와 있던 provider 인터페이스와 mock fallback 흐름을 그대로 살리면서, `models.py`의 transcript / decision / action item 타입을 백엔드가 직접 재사용하도록 맞췄습니다.

## 사용자 영향
이제 요약 백엔드는 내부 전용 타입을 따로 만들지 않고, STT와 출력기에서 쓰는 공용 모델과 같은 구조를 공유합니다. mock provider 기준으로는 실제 `SummaryBackend().summarize(...)` 호출도 바로 확인할 수 있습니다.

## 수정 내용
- `meeting-summary-tool/src/meeting_summary_tool/models.py`에 `speaker_map`, `iter_lines()`, `render_text()`, `confidence` 필드를 추가해 요약 백엔드와 맞췄습니다.
- `meeting-summary-tool/src/meeting_summary_tool/summarize/backend.py`에서 중복 정의하던 transcript / decision / action item 타입을 제거하고 공용 모델을 import하도록 정리했습니다.
- mock fallback 경로와 provider 인터페이스는 유지했습니다.

## 확인
- `python -m py_compile`로 `models.py`, `backend.py` 문법을 확인했습니다.
- 샘플 transcript로 `SummaryBackend().summarize(...)`를 호출해 mock provider 결과가 생성되는 것을 확인했습니다.

Closes #90
