### PR TITLE
[codex] 회의 요약 도구 end-to-end 파이프라인 연결

### DIFF
--- a/meeting-summary-tool/src/meeting_summary_tool/cli.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/cli.py
@@ -7,7 +7,9 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from meeting_summary_tool.models import AudioInput
+from meeting_summary_tool.pipeline import PipelineExecutionError
 from meeting_summary_tool.pipeline import prepare_pipeline_run
+from meeting_summary_tool.pipeline import run_pipeline
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -41,6 +43,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output-dir",
         help="결과 저장 디렉토리",
+    )
+    parser.add_argument(
+        "--summary-provider",
+        default="mock",
+        choices=["mock", "ollama", "openai"],
+        help="요약 백엔드 선택",
+    )
+    parser.add_argument(
+        "--summary-model",
+        help="요약 모델 이름",
     )
     return parser
 
@@ -94,6 +106,21 @@ def _render_run_summary(audio_input: AudioInput) -> list[str]:
     return lines
 
 
+def _render_result_summary(markdown_paths: list[Path], warnings: list[str]) -> list[str]:
+    """Build a user-facing result summary."""
+
+    lines = ["meeting-summary-tool 파이프라인 실행이 완료되었습니다."]
+    if markdown_paths:
+        lines.append("- 생성 파일:")
+        for path in markdown_paths:
+            lines.append(f"  - {path}")
+    if warnings:
+        lines.append("- 경고:")
+        for warning in warnings:
+            lines.append(f"  - {warning}")
+    return lines
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI entrypoint."""
 
@@ -110,11 +137,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     for line in _render_run_summary(prepared_run.audio_input):
         print(line)
     print(f"- 정규화된 출력 디렉토리: {prepared_run.output_dir}")
-    if prepared_run.warnings:
-        print("- 경고:")
-        for warning in prepared_run.warnings:
-            print(f"  - {warning}")
-    print("다음 단계로 STT / 요약 파이프라인을 연결하면 됩니다.")
+
+    try:
+        result = run_pipeline(
+            prepared_run,
+            model_provider=args.summary_provider,
+            model_name=args.summary_model,
+        )
+    except PipelineExecutionError as exc:
+        parser.exit(status=1, message=f"파이프라인 실행 실패: {exc}\n")
+
+    markdown_paths = [artifact.path for artifact in result.artifacts if artifact.kind == "markdown"]
+    for line in _render_result_summary(markdown_paths, result.warnings):
+        print(line)
     return 0
 
 

--- a/meeting-summary-tool/src/meeting_summary_tool/pipeline.py
+++ b/meeting-summary-tool/src/meeting_summary_tool/pipeline.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from datetime import datetime
 from pathlib import Path
 
 from meeting_summary_tool.config import resolve_default_output_dir
+from meeting_summary_tool.io.output_writer import write_markdown_output
+from meeting_summary_tool.models import ActionItem
 from meeting_summary_tool.models import AudioInput
+from meeting_summary_tool.models import DecisionItem
+from meeting_summary_tool.models import PipelineResult
+from meeting_summary_tool.models import SavedArtifact
+from meeting_summary_tool.models import SummaryDocument
+from meeting_summary_tool.stt.transcribe import TranscriptionError
+from meeting_summary_tool.stt.transcribe import transcribe_audio
+from meeting_summary_tool.summarize.backend import SummaryBackend
+from meeting_summary_tool.summarize.backend import SummaryRequest
+from meeting_summary_tool.summarize.backend import SummaryResult
+from meeting_summary_tool.summarize.backend import build_default_backend
 
 
 @dataclass(slots=True)
@@ -16,6 +29,10 @@ class PreparedPipelineRun:
     audio_input: AudioInput
     output_dir: Path
     warnings: list[str] = field(default_factory=list)
+
+
+class PipelineExecutionError(RuntimeError):
+    """Raised when the end-to-end pipeline cannot complete."""
 
 
 def prepare_pipeline_run(audio_input: AudioInput) -> PreparedPipelineRun:
@@ -36,10 +53,91 @@ def prepare_pipeline_run(audio_input: AudioInput) -> PreparedPipelineRun:
     )
 
 
-def run_pipeline() -> None:
-    """Placeholder pipeline entrypoint.
+def _normalized_audio_input(prepared_run: PreparedPipelineRun) -> AudioInput:
+    """Apply default values needed for actual execution."""
 
-    The real orchestration logic is added in follow-up issues.
-    """
+    meeting_date = prepared_run.audio_input.meeting_date or datetime.now().date().isoformat()
+    meeting_title = prepared_run.audio_input.meeting_title or prepared_run.audio_input.audio_path.stem
+    return replace(
+        prepared_run.audio_input,
+        meeting_title=meeting_title,
+        meeting_date=meeting_date,
+        output_dir=prepared_run.output_dir,
+    )
 
-    raise NotImplementedError("Pipeline orchestration is not implemented yet.")
+
+def _build_summary_document(summary_result: SummaryResult) -> SummaryDocument:
+    """Convert backend summary output into the shared summary model."""
+
+    return SummaryDocument(
+        summary=summary_result.summary,
+        decisions=[
+            DecisionItem(text=item.text, confidence=item.confidence)
+            for item in summary_result.decisions
+        ],
+        action_items=[
+            ActionItem(
+                text=item.text,
+                confidence=item.confidence,
+                owner=item.owner,
+                due_date=item.due_date,
+            )
+            for item in summary_result.action_items
+        ],
+        provider=summary_result.provider,
+        model_name=summary_result.model_name,
+        warnings=list(summary_result.warnings),
+    )
+
+
+def run_pipeline(
+    prepared_run: PreparedPipelineRun,
+    *,
+    model_provider: str = "mock",
+    model_name: str | None = None,
+    summary_backend: SummaryBackend | None = None,
+) -> PipelineResult:
+    """Run the minimum end-to-end pipeline."""
+
+    normalized_input = _normalized_audio_input(prepared_run)
+    pipeline_warnings = list(prepared_run.warnings)
+
+    try:
+        transcript = transcribe_audio(normalized_input.audio_path)
+    except (FileNotFoundError, ValueError, TranscriptionError) as exc:
+        raise PipelineExecutionError(str(exc)) from exc
+
+    backend = summary_backend or build_default_backend()
+    summary_request = SummaryRequest(
+        transcript=transcript,
+        job_id=f"{normalized_input.meeting_date}-{normalized_input.meeting_title}",
+        meeting_title=normalized_input.meeting_title,
+        meeting_date=normalized_input.meeting_date,
+        model_provider=model_provider,
+        model_name=model_name,
+        output_dir=normalized_input.output_dir,
+    )
+
+    try:
+        summary_result = backend.summarize(summary_request)
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        raise PipelineExecutionError(f"요약 단계 실행에 실패했습니다: {exc}") from exc
+
+    summary = _build_summary_document(summary_result)
+    pipeline_warnings.extend(transcript.warnings)
+    pipeline_warnings.extend(summary.warnings)
+
+    result = PipelineResult(
+        audio_input=normalized_input,
+        transcript=transcript,
+        summary=summary,
+        warnings=pipeline_warnings,
+    )
+
+    try:
+        output_path = write_markdown_output(result)
+    except Exception as exc:  # pragma: no cover - filesystem boundary
+        raise PipelineExecutionError(f"Markdown 저장에 실패했습니다: {exc}") from exc
+
+    result.artifacts.append(SavedArtifact(path=output_path, kind="markdown"))
+    return result


### PR DESCRIPTION
## 요약
- CLI가 회의 요약 파이프라인을 직접 실행하도록 연결했습니다.
- 파이프라인이 전사 -> 요약 -> 마크다운 저장까지 한 번에 수행하도록 구성했습니다.
- 요약 백엔드 선택을 위한 CLI 옵션을 추가했습니다.

## 변경 사항
- `meeting-summary-tool/src/meeting_summary_tool/pipeline.py`
  - 전사 결과를 요약 요청으로 연결하는 end-to-end 파이프라인 구현
  - 요약 결과를 `SummaryDocument`로 변환 후 마크다운 출력까지 저장
  - 파이프라인 단계 실패를 `PipelineExecutionError`로 감싸서 CLI에서 처리 가능하도록 정리
- `meeting-summary-tool/src/meeting_summary_tool/cli.py`
  - `--summary-provider`, `--summary-model` 옵션 추가
  - 파이프라인 실행 및 오류 처리 연결
  - 생성된 마크다운 경로와 경고 요약 출력 추가

## 검증
- `python -m py_compile meeting-summary-tool/src/meeting_summary_tool/cli.py meeting-summary-tool/src/meeting_summary_tool/pipeline.py`
- 전사 함수를 스텁으로 대체한 CLI end-to-end 실행으로 마크다운 파일 생성 확인

## 참고
- 실제 오디오 파일 기반 전체 경로 검증은 이번 PR에서 수행하지 않았고, 전사 단계는 스텁 실행으로 흐름을 확인했습니다.

Closes #97
